### PR TITLE
Ensure that contexts are updated when an environment is updated

### DIFF
--- a/src/Authentication.ResourceManager/AzureRmProfile.cs
+++ b/src/Authentication.ResourceManager/AzureRmProfile.cs
@@ -529,6 +529,14 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Models
 
                 EnvironmentTable[environment.Name] = mergedEnvironment;
                 result = true;
+                foreach (var context in Contexts)
+                {
+                    if (context.Value.Environment != null &&
+                        context.Value.Environment.Name == environment.Name)
+                    {
+                        context.Value.Environment = mergedEnvironment;
+                    }
+                }
             }
 
             return result;


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-powershell/issues/7008

When an environment is updated using `Add/Set-AzureRmEnvironment`, ensure that any context using that environment is updated as well rather than just the `EnvironmentTable` in the context file.