### PR TITLE
[WIP] Serialize SP secret with context to allow for token to be acquired with new session

### DIFF
--- a/src/Authentication.Abstractions/AzureAccount.cs
+++ b/src/Authentication.Abstractions/AzureAccount.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// Login Uri for Managed Service Login
         /// </summary>
         MSILoginUri = "MSILoginUri",
-        
+
         /// <summary>
         /// Backup login Uri for MSI
         /// </summary>
@@ -134,7 +134,19 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// <summary>
         /// Secret that may be used with MSI login
         /// </summary>
-        MSILoginSecret = "MSILoginSecret";
+        MSILoginSecret = "MSILoginSecret",
+
+
+        /// <summary>
+        /// Service principal name used for login
+        /// </summary>
+        ServicePrincipalName = "ServicePrincipalName",
+
+
+        /// <summary>
+        /// Service principal secret used for login
+        /// </summary>
+        ServicePrincipalSecret = "ServicePrincipalSecret";
         }
     }
 }

--- a/src/Authentication/Authentication/ServicePrincipalKeyStore.Netcore.cs
+++ b/src/Authentication/Authentication/ServicePrincipalKeyStore.Netcore.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Azure.Commands.Common.Authentication
     {
         private static IDictionary<string, SecureString> _credentials = new Dictionary<string, SecureString>();
 
+        public static IDictionary<string, SecureString> Credentials { get => _credentials; set => _credentials = value; }
+
         public static void SaveKey(string appId, string tenantId, SecureString serviceKey)
         {
             var key = CreateKey(appId, tenantId);


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-powershell/issues/6743

Serialize the value of the service principal secret when user logs in using SPN and retrieve the value when getting the service principal token in a new session.