### PR TITLE
Fix the issue with property names being not shown in the warning message

### DIFF
--- a/src/Common/CustomAttributes/CmdletOutputBreakingChangeAttribute.cs
+++ b/src/Common/CustomAttributes/CmdletOutputBreakingChangeAttribute.cs
@@ -79,7 +79,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
                     message.Append(Resources.BreakingChangesAttributesCmdLetOutputPropertiesRemoved);
                     foreach (string property in DeprecatedOutputProperties)
                     {
-                        message.Append(" '{property}'");
+                        message.Append(" '" + property + "'");
                     }
                 }
 
@@ -88,7 +88,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
                     message.Append(Resources.BreakingChangesAttributesCmdLetOutputPropertiesAdded);
                     foreach (string property in NewOutputProperties)
                     {
-                        message.Append(" '{property}'");
+                        message.Append(" '" + property + "'");
                     }
                 }
             }


### PR DESCRIPTION
fix for issue #41