### PR TITLE
Tagging #if statements for Az

### DIFF
--- a/src/Authentication/Authentication/ITokenProvider.cs
+++ b/src/Authentication/Authentication/ITokenProvider.cs
@@ -38,11 +38,11 @@ namespace Microsoft.Azure.Commands.Common.Authentication
         IAccessToken GetAccessToken(
             AdalConfiguration config,
             string promptBehavior,
-			Action<string> promptAction,
+            Action<string> promptAction,
             string userId,
             SecureString password,
             string credentialType);
-			
+// TODO: Remove IfDef code
 #if !NETSTANDARD
         /// <summary>
         /// Get a new authentication token for the given environment
@@ -57,6 +57,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication
             string principalId,
             string certificateThumbprint,
             string credentialType);
-#endif	
+#endif
     }
 }

--- a/src/Common/AzureDataCmdlet.cs
+++ b/src/Common/AzureDataCmdlet.cs
@@ -30,19 +30,20 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                if (RMProfile != null && RMProfile.DefaultContext != null && RMProfile.DefaultContext.Environment != null)
+                if (RMProfile?.DefaultContext?.Environment != null)
                 {
                     return RMProfile.DefaultContext;
                 }
-#if !NETSTANDARD
+// TODO: Remove IfDef
+#if NETSTANDARD
+                return null;
+#else
                 if (SMProfile == null || SMProfile.DefaultContext == null)
                 {
                     throw new InvalidOperationException(Resources.NoCurrentContextForDataCmdlet);
                 }
 
                 return SMProfile.DefaultContext;
-#else
-                return null;
 #endif
             }
         }
@@ -62,7 +63,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         }
         /// <summary>
         /// Guards execution of the given action using ShouldProcess and ShouldContinue.  The optional 
-        /// useSHouldContinue predicate determines whether SHouldContinue should be called for this 
+        /// useShouldContinue predicate determines whether ShouldContinue should be called for this 
         /// particular action (e.g. a resource is being overwritten). By default, both 
         /// ShouldProcess and ShouldContinue will be executed.  Cmdlets that use this method overload 
         /// must have a force parameter.
@@ -82,6 +83,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
+// TODO: Remove IfDef
 #if NETSTANDARD
                 return null;
 #else

--- a/src/Common/AzurePowerShell.cs
+++ b/src/Common/AzurePowerShell.cs
@@ -38,18 +38,15 @@ namespace Microsoft.WindowsAzure.Commands.Common
 
         public const string TokenCacheFile = "TokenCache.dat";
 
-        public static ProductInfoHeaderValue UserAgentValue = new ProductInfoHeaderValue(
-            "AzurePowershell",
-            string.Format("v{0}", AzurePowerShell.AssemblyVersion));
+        public static ProductInfoHeaderValue UserAgentValue = new ProductInfoHeaderValue("AzurePowershell", string.Format("v{0}", AssemblyVersion));
 
         public static string ProfileDirectory = Path.Combine(
+// TODO: Remove IfDef
 #if NETSTANDARD
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".Azure");
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".Azure");
 
         public static string OldProfileDirectory = Path.Combine(
 #endif
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "Windows Azure PowerShell");
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Windows Azure PowerShell");
     }
 }

--- a/src/Common/Utilities/Validate.cs
+++ b/src/Common/Utilities/Validate.cs
@@ -29,6 +29,8 @@ namespace Microsoft.WindowsAzure.Commands.Common
     /// </summary>
     public static class Validate
     {
+// TODO: Remove IfDef code
+#if !NETSTANDARD
         [Flags]
         enum InternetConnectionState : int
         {
@@ -39,6 +41,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             INTERNET_CONNECTION_OFFLINE = 0x20,
             INTERNET_CONNECTION_CONFIGURED = 0x40
         }
+#endif
 
         /// <summary>
         /// Validates against given string if null or empty.
@@ -49,19 +52,16 @@ namespace Microsoft.WindowsAzure.Commands.Common
         /// <param name="useDefaultMessage">Indicates either to use messageData as actual message or parameter name</param>
         public static void ValidateStringIsNullOrEmpty(string data, string messageData, bool useDefaultMessage = true)
         {
-            if (string.IsNullOrEmpty(data))
+            if (!string.IsNullOrEmpty(data)) return;
+
+            // In this case use messageData parameter as name for null/empty string.
+            if (useDefaultMessage)
             {
-                // In this case use messageData parameter as name for null/empty string.
-                if (useDefaultMessage)
-                {
-                    throw new ArgumentException(string.Format(Resources.InvalidOrEmptyArgumentMessage, messageData));
-                }
-                else
-                {
-                    // Use the message provided by the user
-                    throw new ArgumentException(messageData);
-                }
+                throw new ArgumentException(string.Format(Resources.InvalidOrEmptyArgumentMessage, messageData));
             }
+
+            // Use the message provided by the user
+            throw new ArgumentException(messageData);
         }
 
         /// <summary>
@@ -81,12 +81,12 @@ namespace Microsoft.WindowsAzure.Commands.Common
         /// Check a file path for invalid characters
         /// </summary>
         /// <param name="element">The file name</param>
-        /// <param name="exceptionMessage">The exception messag eto throw if invalid characters are found</param>
+        /// <param name="exceptionMessage">The exception message to throw if invalid characters are found</param>
         public static void ValidateFileName(string element, string exceptionMessage = null)
         {
             try
             {
-                string fileName = Path.GetFileName(element);
+                var fileName = Path.GetFileName(element);
 
                 if (fileName.IndexOfAny(Path.GetInvalidFileNameChars()) != -1)
                 {
@@ -119,17 +119,16 @@ namespace Microsoft.WindowsAzure.Commands.Common
         /// <param name="exceptionMessage">The exception message to throw if the directory does not exist</param>
         public static void ValidateDirectoryExists(string directory, string exceptionMessage = null)
         {
-            string msg = string.Format(Resources.PathDoesNotExist, directory);
+            var msg = string.Format(Resources.PathDoesNotExist, directory);
 
-            if (!FileUtilities.DataStore.DirectoryExists(directory))
+            if (FileUtilities.DataStore.DirectoryExists(directory)) return;
+
+            if (!string.IsNullOrEmpty(exceptionMessage))
             {
-                if (!string.IsNullOrEmpty(exceptionMessage))
-                {
-                    msg = exceptionMessage;
-                }
-
-                throw new FileNotFoundException(msg);
+                msg = exceptionMessage;
             }
+
+            throw new FileNotFoundException(msg);
         }
 
         /// <summary>
@@ -146,13 +145,13 @@ namespace Microsoft.WindowsAzure.Commands.Common
         }
 
         /// <summary>
-        /// Verify that the given file has the required extnsion
+        /// Verify that the given file has the required extension
         /// </summary>
         /// <param name="filePath">The file path</param>
         /// <param name="desiredExtention">The extension desired</param>
         public static void ValidateFileExtention(string filePath, string desiredExtention)
         {
-            bool invalidExtension = Convert.ToBoolean(string.Compare(Path.GetExtension(filePath), desiredExtention, true));
+            var invalidExtension = Convert.ToBoolean(string.Compare(Path.GetExtension(filePath), desiredExtention, true));
 
             if (invalidExtension)
             {
@@ -163,7 +162,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         /// Validate the form of the given dns name
         /// </summary>
         /// <param name="dnsName">The dns name to check</param>
-        /// <param name="parameterName">The name of the parameter containign the dns value in the source method calling this fucntion</param>
+        /// <param name="parameterName">The name of the parameter containing the dns value in the source method calling this function</param>
         public static void ValidateDnsName(string dnsName, string parameterName)
         {
             if (Uri.CheckHostName(dnsName) != UriHostNameType.Dns || dnsName.EndsWith("-"))
@@ -190,7 +189,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
                 // Dns doesn't exist
             }
         }
-
+// TODO: Remove IfDef code
 #if !NETSTANDARD
         [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Not necessary for a single p-invoke")]
         [DllImport("WININET", CharSet = CharSet.Auto)]
@@ -198,10 +197,11 @@ namespace Microsoft.WindowsAzure.Commands.Common
 #endif
 
         /// <summary>
-        /// Validate that the intenret connection is working
+        /// Validate that the internet connection is working
         /// </summary>
         public static void ValidateInternetConnection()
         {
+// TODO: Remove IfDef code
 #if !NETSTANDARD
             InternetConnectionState flags = 0;
 
@@ -213,7 +213,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         }
 
         /// <summary>
-        /// Verify that the given test has no whitespace characetrs
+        /// Verify that the given test has no whitespace characters
         /// </summary>
         /// <param name="text">The text to check</param>
         /// <param name="exceptionMessage">The exception message to throw if the check fails</param>
@@ -251,7 +251,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             ValidateStringIsNullOrEmpty(fullPath, name);
             ValidateFileName(fullPath, Resources.IllegalPath);
-            string directoryPath = Path.GetDirectoryName(fullPath);
+            var directoryPath = Path.GetDirectoryName(fullPath);
             if (!string.IsNullOrEmpty(directoryPath))
             {
                 ValidatePath(fullPath, Resources.IllegalPath);

--- a/src/ResourceManager/AzureRMConstants.cs
+++ b/src/ResourceManager/AzureRMConstants.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
 {
     public class AzureRMConstants
     {
+// TODO: Remove IfDef
 #if NETSTANDARD
         public const string AzurePrefix = "Az";
         public const string AzureRMPrefix = "Az";


### PR DESCRIPTION
This is for: https://github.com/Azure/azure-powershell/issues/6793

Status | Name | Location | Notes
-- | -- | -- | --
Tagged | DiskDataStore.cs | C:\Code\azure-powershell-common\src\Authentication.Abstractions\ |  
Low Risk | AzureSessionInitializer.cs | C:\Code\azure-powershell-common\src\Authentication\ | Primary changes covered in   https://github.com/Azure/azure-powershell/issues/6166
Tagged | AdalTokenProvider.cs | C:\Code\azure-powershell-common\src\Authentication\Authentication\ |  
Tagged | ITokenProvider.cs | C:\Code\azure-powershell-common\src\Authentication\Authentication\ |  
Tagged | KeyStoreApplicationCredentialProvider.cs | C:\Code\azure-powershell-common\src\Authentication\Authentication\ |  
Tagged | ProtectedFileTokenCache.cs | C:\Code\azure-powershell-common\src\Authentication\Authentication\ |  
Tagged | ServicePrincipalTokenProvider.cs | C:\Code\azure-powershell-common\src\Authentication\Authentication\ |  
High Risk | AuthenticationFactory.cs | C:\Code\azure-powershell-common\src\Authentication\Factories\ | No Certificate-based authentication
Tagged | AzureDataCmdlet.cs | C:\Code\azure-powershell-common\src\Common\ |  
Tagged | AzurePowerShell.cs | C:\Code\azure-powershell-common\src\Common\ |  
Tagged | GeneralUtilities.cs | C:\Code\azure-powershell-common\src\Common\Utilities\ |  
Tagged | Validate.cs | C:\Code\azure-powershell-common\src\Common\Utilities\ |  
Tagged | AzureRMConstants.cs | C:\Code\azure-powershell-common\src\ResourceManager\ |  

### Key
- **Tagged**: The `#if NETSTANDARD` was simply tagged with either `// TODO: Remove IfDef` or `// TODO: Remove IfDef code`. These changes are unlikely to cause issues and/or won't require any special attention for migration.
- **Low Risk**: There are differences between net452 and netstandard. These may need information added to the migration guide. They have minimal/low risk changes.
- **High Risk**: There are differences between net452 and netstandard. These likely need information added to the migration guide. The changes may fundamentally alter how the files/cmdlets works.
- **Resolved**: The `#if NETSTANDARD` was removed and not necessary.