### PR TITLE
Test controller update

### DIFF
--- a/src/TestFx/ITestRunner.cs
+++ b/src/TestFx/ITestRunner.cs
@@ -12,10 +12,13 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Azure.Commands.TestFx
 {
     public interface ITestRunner
     {
         void RunTestScript(params string[] scripts);
+        void RunTestScript(Action setUp, Action tearDown, params string[] scripts);
     }
 }

--- a/src/TestFx/ITestRunnerFactory.cs
+++ b/src/TestFx/ITestRunnerFactory.cs
@@ -28,5 +28,6 @@ namespace Microsoft.Azure.Commands.TestFx
         ITestRunnerFactory WithNewRmModules(Func<EnvironmentSetupHelper, string[]> buildModuleList);
         ITestRunnerFactory WithExtraUserAgentsToIgnore(Dictionary<string, string> userAgentsToIgnore);
         ITestRunnerFactory WithRecordMatcher(RecordMatcherDelegate recordMatcher);
+        ITestRunnerFactory WithNewRecordMatcherArguments(Dictionary<string, string> userAgentsToIgnore, Dictionary<string, string> resourceProviders);
     }
 }


### PR DESCRIPTION
Zero guid replaced with dummy guid for the  tenantId to avoid wrong Azure env exception from KeyVault cmdlets. pre and post action params added to runScript method.