### PR TITLE
Fix incorrect output of Get-Location when using UseCanonical

### DIFF
--- a/src/ScenarioTest.ResourceManager/Common.ps1
+++ b/src/ScenarioTest.ResourceManager/Common.ps1
@@ -603,7 +603,7 @@ function Get-Location
         }
     }
     $locations = $resourceTypes.Locations
-    if($UseCanonical)
+    if($UseCanonical -and $locations -ne $null)
     {
         $locations = $locations | ForEach-Object { Normalize-Location $_ }
     }


### PR DESCRIPTION
If `$resourceType` passed in `Get-Location` isn't found and `UseCanonical` is used, the function returns null instead of default location.

Since no resource type was found, `locations` array is `$null`. So when each element of `locations` is being normalized through `ForEach-Object` the following statement returns non-empty array: `$null | ForEach-Object`. Because of that, if-statement `$locations.Count -ne 0` is true and `$locations[0]` returns `@($null)[0]` i.e. `$null`

Example:

```
PS C:\> Get-Location "Microsoft.Network" "Usages" "westus"
West US
PS C:\> Get-Location "Microsoft.Network" "Usages" "westus" -UseCanonical

```