### PR TITLE
1: Change AzureRM.Profile to AzureRM.Accounts

### DIFF
--- a/src/Common/Properties/Resources.Designer.cs
+++ b/src/Common/Properties/Resources.Designer.cs
@@ -236,8 +236,8 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         ///The data is anonymous and does not include commandline argument values.
         ///The data is collected by Microsoft.
         ///
-        ///Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Profile module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
-        ///Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Profile module.  To enable  [rest of string was truncated]&quot;;.
+        ///Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Accounts module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
+        ///Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Accounts module.  To enable  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ARMDataCollectionMessage {
             get {

--- a/src/Common/Properties/Resources.Designer.cs
+++ b/src/Common/Properties/Resources.Designer.cs
@@ -236,8 +236,8 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         ///The data is anonymous and does not include commandline argument values.
         ///The data is collected by Microsoft.
         ///
-        ///Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Accounts module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
-        ///Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Accounts module.  To enable  [rest of string was truncated]&quot;;.
+        ///Use the Disable-AzDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the Az.Accounts module. To disable data collection: PS &gt; Disable-AzDataCollection.
+        ///Use the Enable-AzDataCollection cmdlet to turn the feature On. The cmdlet can be found in the Az.Accounts module. To enable  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ARMDataCollectionMessage {
             get {

--- a/src/Common/Properties/Resources.resx
+++ b/src/Common/Properties/Resources.resx
@@ -1473,8 +1473,8 @@ The file needs to be a PowerShell script (.ps1 or .psm1).</value>
 The data is anonymous and does not include commandline argument values.
 The data is collected by Microsoft.
 
-Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Accounts module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
-Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Accounts module.  To enable data collection: PS &gt; Enable-AzureRmDataCollection.</value>
+Use the Disable-AzDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the Az.Accounts module. To disable data collection: PS &gt; Disable-AzDataCollection.
+Use the Enable-AzDataCollection cmdlet to turn the feature On. The cmdlet can be found in the Az.Accounts module. To enable data collection: PS &gt; Enable-AzDataCollection.</value>
   </data>
   <data name="DataCollectionActivity" xml:space="preserve">
     <value>Microsoft Azure PowerShell Data Collection Confirmation</value>

--- a/src/Common/Properties/Resources.resx
+++ b/src/Common/Properties/Resources.resx
@@ -1473,8 +1473,8 @@ The file needs to be a PowerShell script (.ps1 or .psm1).</value>
 The data is anonymous and does not include commandline argument values.
 The data is collected by Microsoft.
 
-Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Profile module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
-Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Profile module.  To enable data collection: PS &gt; Enable-AzureRmDataCollection.</value>
+Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Accounts module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
+Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Accounts module.  To enable data collection: PS &gt; Enable-AzureRmDataCollection.</value>
   </data>
   <data name="DataCollectionActivity" xml:space="preserve">
     <value>Microsoft Azure PowerShell Data Collection Confirmation</value>

--- a/src/ResourceManager/Properties/Resources.Designer.cs
+++ b/src/ResourceManager/Properties/Resources.Designer.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common.Properties {
         ///The data is anonymous and does not include commandline argument values.
         ///The data is collected by Microsoft.
         ///
-        ///Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Profile module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
-        ///Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Profile module.  To enable  [rest of string was truncated]&quot;;.
+        ///Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Accounts module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
+        ///Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Accounts module.  To enable  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ARMDataCollectionMessage {
             get {

--- a/src/ResourceManager/Properties/Resources.Designer.cs
+++ b/src/ResourceManager/Properties/Resources.Designer.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common.Properties {
         ///The data is anonymous and does not include commandline argument values.
         ///The data is collected by Microsoft.
         ///
-        ///Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Accounts module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
-        ///Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Accounts module.  To enable  [rest of string was truncated]&quot;;.
+        ///Use the Disable-AzDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the Az.Accounts module. To disable data collection: PS &gt; Disable-AzDataCollection.
+        ///Use the Enable-AzDataCollection cmdlet to turn the feature On. The cmdlet can be found in the Az.Accounts module. To enable  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ARMDataCollectionMessage {
             get {

--- a/src/ResourceManager/Properties/Resources.resx
+++ b/src/ResourceManager/Properties/Resources.resx
@@ -140,8 +140,8 @@
 The data is anonymous and does not include commandline argument values.
 The data is collected by Microsoft.
 
-Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Profile module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
-Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Profile module.  To enable data collection: PS &gt; Enable-AzureRmDataCollection.</value>
+Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Accounts module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
+Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Accounts module.  To enable data collection: PS &gt; Enable-AzureRmDataCollection.</value>
   </data>
   <data name="DataCollectionSaveFileInformation" xml:space="preserve">
     <value>The setting profile has been saved to the following path '{0}'.</value>

--- a/src/ResourceManager/Properties/Resources.resx
+++ b/src/ResourceManager/Properties/Resources.resx
@@ -140,8 +140,8 @@
 The data is anonymous and does not include commandline argument values.
 The data is collected by Microsoft.
 
-Use the Disable-AzureRmDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the AzureRM.Accounts module.  To disable data collection: PS &gt; Disable-AzureRmDataCollection.
-Use the Enable-AzureRmDataCollection cmdlet to turn the feature On. The cmdlet can be found in the AzureRM.Accounts module.  To enable data collection: PS &gt; Enable-AzureRmDataCollection.</value>
+Use the Disable-AzDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the Az.Accounts module. To disable data collection: PS &gt; Disable-AzDataCollection.
+Use the Enable-AzDataCollection cmdlet to turn the feature On. The cmdlet can be found in the Az.Accounts module. To enable data collection: PS &gt; Enable-AzDataCollection.</value>
   </data>
   <data name="DataCollectionSaveFileInformation" xml:space="preserve">
     <value>The setting profile has been saved to the following path '{0}'.</value>

--- a/src/ScenarioTest.ResourceManager/EnvironmentSetupHelper.cs
+++ b/src/ScenarioTest.ResourceManager/EnvironmentSetupHelper.cs
@@ -72,13 +72,13 @@ namespace Microsoft.WindowsAzure.Commands.ScenarioTest
 #endif
         public EnvironmentSetupHelper()
         {
-            var module = GetModuleManifest(RmDirectory, "AzureRM.Profile");
+            var module = GetModuleManifest(RmDirectory, "AzureRM.Accounts");
             if (string.IsNullOrWhiteSpace(module))
             {
-                throw new InvalidOperationException("Could not find profile module");
+                throw new InvalidOperationException("Could not find Accounts module");
             }
 
-            LogIfNotNull($"Profile Module path: {module}");
+            LogIfNotNull($"Accounts Module path: {module}");
             RMProfileModule = module;
             module = GetModuleManifest(RmDirectory, "AzureRM.Resources");
             LogIfNotNull($"Resources Module path: {module}");
@@ -99,8 +99,8 @@ namespace Microsoft.WindowsAzure.Commands.ScenarioTest
             LogIfNotNull($"Network Module path: {module}");
             RMNetworkModule = module;
 
-            module = GetModuleManifest(StackRmDirectory, "AzureRM.Profile");
-            LogIfNotNull($"Stack Profile Module path: {module}");
+            module = GetModuleManifest(StackRmDirectory, "AzureRM.Accounts");
+            LogIfNotNull($"Stack Accounts Module path: {module}");
             StackRMProfileModule = module;
             module = GetModuleManifest(StackRmDirectory, "AzureRM.Resources");
             LogIfNotNull($"Stack Resources Module path: {module}");
@@ -540,7 +540,7 @@ namespace Microsoft.WindowsAzure.Commands.ScenarioTest
             if (mode == AzureModule.AzureProfile)
             {
                 this.modules.Add(Path.Combine(PackageDirectory, @"ServiceManagement\Azure\Azure.psd1"));
-                this.modules.Add(Path.Combine(PackageDirectory, @"ResourceManager\AzureResourceManager\AzureRM.Profile\AzureRM.Profile.psd1"));
+                this.modules.Add(Path.Combine(PackageDirectory, @"ResourceManager\AzureResourceManager\AzureRM.Accounts\AzureRM.Accounts.psd1"));
                 this.modules.Add(Path.Combine(PackageDirectory, @"ResourceManager\AzureResourceManager\AzureRM.Resources\AzureRM.Resources.psd1"));
                 this.modules.Add(Path.Combine(PackageDirectory, @"ResourceManager\AzureResourceManager\AzureRM.Resources\AzureRM.Tags.psd1"));
             }
@@ -560,7 +560,7 @@ namespace Microsoft.WindowsAzure.Commands.ScenarioTest
             if (mode == AzureModule.AzureProfile)
             {
                 this.modules.Add(Path.Combine(PackageDirectoryFromCommon, @"ServiceManagement\Azure\Azure.psd1"));
-                this.modules.Add(Path.Combine(PackageDirectoryFromCommon, @"ResourceManager\AzureResourceManager\AzureRM.Profile\AzureRM.Profile.psd1"));
+                this.modules.Add(Path.Combine(PackageDirectoryFromCommon, @"ResourceManager\AzureResourceManager\AzureRM.Accounts\AzureRM.Accounts.psd1"));
                 this.modules.Add(Path.Combine(PackageDirectoryFromCommon, @"ResourceManager\AzureResourceManager\AzureRM.Resources\AzureRM.Resources.psd1"));
                 this.modules.Add(Path.Combine(PackageDirectoryFromCommon, @"ResourceManager\AzureResourceManager\AzureRM.Resources\AzureRM.Tags.psd1"));
             }
@@ -570,7 +570,7 @@ namespace Microsoft.WindowsAzure.Commands.ScenarioTest
             }
             else if (mode == AzureModule.AzureResourceManager)
             {
-                this.modules.Add(Path.Combine(PackageDirectoryFromCommon, @"ResourceManager\AzureResourceManager\AzureRM.Profile\AzureRM.Profile.psd1"));
+                this.modules.Add(Path.Combine(PackageDirectoryFromCommon, @"ResourceManager\AzureResourceManager\AzureRM.Accounts\AzureRM.Accounts.psd1"));
                 this.modules.Add(Path.Combine(PackageDirectoryFromCommon, @"ResourceManager\AzureResourceManager\AzureRM.Resources\AzureRM.Resources.psd1"));
                 this.modules.Add(Path.Combine(PackageDirectoryFromCommon, @"ResourceManager\AzureResourceManager\AzureRM.Resources\AzureRM.Tags.psd1"));
             }


### PR DESCRIPTION
Updated usages of AzureRM.Profile to AzureRM.Accounts. The rename of AzureRM -> Az will be handled in the future across the entire repo. For now, we need `Profile` to say `Accounts` for tests to run in our module repo.