### PR TITLE
Fixed GetId throwing on null IAzureSubscription

### DIFF
--- a/src/Authentication.Abstractions/Extensions/AzureSubscriptionExtensions.cs
+++ b/src/Authentication.Abstractions/Extensions/AzureSubscriptionExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// <returns>The globally unique id, if the id is set, otherwise, the enpty Guid</returns>
         public static Guid GetId(this IAzureSubscription subscription)
         {
-            return subscription.Id == null? Guid.Empty: new Guid(subscription.Id);
+            return subscription?.Id == null ? Guid.Empty : new Guid(subscription.Id);
         }
 
         /// <summary>


### PR DESCRIPTION
The intent of `GetId` is to always return a Guid, even if it is just an empty Guid. This method throws if the `subscription` parameter is `null` (which is possible since it is an extension method). I added a `?` prior to attempting to access `Id` so the method evaluates correctly.