### PR TITLE
Resources module removed from the list of preset RM modules.

### DIFF
--- a/src/TestFx/TestManager.cs
+++ b/src/TestFx/TestManager.cs
@@ -74,7 +74,6 @@ namespace Microsoft.Azure.Commands.TestFx
             RmModules = new List<string>
             {
                 Helper.RMProfileModule,
-                Helper.RMResourceModule,
             };
 
             RecordMatcher = (ignoreResourcesClient, resourceProviders, userAgentsToIgnore) =>


### PR DESCRIPTION
Issue https://github.com/Azure/azure-powershell/issues/8157 fix.