### PR TITLE
change the deprecated licenseUrl element to license file instead

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -16,24 +16,5 @@
     <Exec Command="dotnet msbuild build/pack.proj $(CommandArguments)" />
   </Target>
 
-  <Target Name="CpLicense">
-    <Exec Command="copy LICENSE.txt src\Aks" />
-    <Exec Command="copy LICENSE.txt src\Authentication.Abstractions" />
-    <Exec Command="copy LICENSE.txt src\Authorization" />
-    <Exec Command="copy LICENSE.txt src\Common" />
-    <Exec Command="copy LICENSE.txt src\Compute" />
-    <Exec Command="copy LICENSE.txt src\Graph.Rbac" />
-    <Exec Command="copy LICENSE.txt src\KeyVault" />
-    <Exec Command="copy LICENSE.txt src\Monitor" />
-    <Exec Command="copy LICENSE.txt src\Network" />
-    <Exec Command="copy LICENSE.txt src\PolicyInsights" />
-    <Exec Command="copy LICENSE.txt src\Probe.Test" />
-    <Exec Command="copy LICENSE.txt src\ResourceManager" />
-    <Exec Command="copy LICENSE.txt src\Storage" />
-    <Exec Command="copy LICENSE.txt src\Storage.Management" />
-    <Exec Command="copy LICENSE.txt src\Strategies" />
-    <Exec Command="copy LICENSE.txt src\Websites" />
-  </Target>
-
   <Target Name="All" DependsOnTargets="Build;Pack" />
 </Project>

--- a/build.proj
+++ b/build.proj
@@ -16,5 +16,24 @@
     <Exec Command="dotnet msbuild build/pack.proj $(CommandArguments)" />
   </Target>
 
+  <Target Name="CpLicense">
+    <Exec Command="copy LICENSE.txt src\Aks" />
+    <Exec Command="copy LICENSE.txt src\Authentication.Abstractions" />
+    <Exec Command="copy LICENSE.txt src\Authorization" />
+    <Exec Command="copy LICENSE.txt src\Common" />
+    <Exec Command="copy LICENSE.txt src\Compute" />
+    <Exec Command="copy LICENSE.txt src\Graph.Rbac" />
+    <Exec Command="copy LICENSE.txt src\KeyVault" />
+    <Exec Command="copy LICENSE.txt src\Monitor" />
+    <Exec Command="copy LICENSE.txt src\Network" />
+    <Exec Command="copy LICENSE.txt src\PolicyInsights" />
+    <Exec Command="copy LICENSE.txt src\Probe.Test" />
+    <Exec Command="copy LICENSE.txt src\ResourceManager" />
+    <Exec Command="copy LICENSE.txt src\Storage" />
+    <Exec Command="copy LICENSE.txt src\Storage.Management" />
+    <Exec Command="copy LICENSE.txt src\Strategies" />
+    <Exec Command="copy LICENSE.txt src\Websites" />
+  </Target>
+
   <Target Name="All" DependsOnTargets="Build;Pack" />
 </Project>

--- a/src/Aks/Aks.csproj
+++ b/src/Aks/Aks.csproj
@@ -17,7 +17,7 @@
     <PackageTags>azure;powershell;clients;aks</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -49,4 +49,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+  </ItemGroup>
+  
 </Project>

--- a/src/Aks/Aks.csproj
+++ b/src/Aks/Aks.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
   
 </Project>

--- a/src/Authentication.Abstractions/Authentication.Abstractions.csproj
+++ b/src/Authentication.Abstractions/Authentication.Abstractions.csproj
@@ -20,7 +20,7 @@
     <PackageTags>azure;powershell;authentication;abstractions</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -50,6 +50,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/Authentication.Abstractions/Authentication.Abstractions.csproj
+++ b/src/Authentication.Abstractions/Authentication.Abstractions.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Authorization/Authorization.csproj
+++ b/src/Authorization/Authorization.csproj
@@ -17,7 +17,7 @@
     <PackageTags>azure;powershell;clients;authorization</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -49,4 +49,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+  </ItemGroup>
+  
 </Project>

--- a/src/Authorization/Authorization.csproj
+++ b/src/Authorization/Authorization.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
   
 </Project>

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -22,7 +22,7 @@
     <PackageTags>azure;powershell;common</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -60,6 +60,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/Compute/Compute.csproj
+++ b/src/Compute/Compute.csproj
@@ -17,7 +17,7 @@
     <PackageTags>azure;powershell;clients;compute</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -33,5 +33,9 @@
     <AssemblyOriginatorKeyFile>..\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>TRACE;RELEASE;NETSTANDARD;SIGN</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+  </ItemGroup>
 
 </Project>

--- a/src/Compute/Compute.csproj
+++ b/src/Compute/Compute.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Graph.Rbac/Graph.Rbac.csproj
+++ b/src/Graph.Rbac/Graph.Rbac.csproj
@@ -20,7 +20,7 @@
     <PackageTags>azure;powershell;clients;graph;rbac</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -56,6 +56,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/Graph.Rbac/Graph.Rbac.csproj
+++ b/src/Graph.Rbac/Graph.Rbac.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Graph.Rbac/Graph.Rbac.nuspec
+++ b/src/Graph.Rbac/Graph.Rbac.nuspec
@@ -7,7 +7,7 @@
     <authors>Microsoft Corporation</authors>
     <owners>Microsoft Corporation</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>https://aka.ms/azps-common-license</licenseUrl>
+    <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/Azure/azure-powershell-common</projectUrl>
     <description>Microsoft Azure PowerShell Clients Graph Rbac library. Only for use with the Azure PowerShell runtime. Not intended for general development use.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>

--- a/src/KeyVault/KeyVault.csproj
+++ b/src/KeyVault/KeyVault.csproj
@@ -17,7 +17,7 @@
     <PackageTags>azure;powershell;clients;keyvault</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -41,6 +41,10 @@
     <PackageReference Include="System.Security.SecureString" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/KeyVault/KeyVault.csproj
+++ b/src/KeyVault/KeyVault.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Monitor/Monitor.csproj
+++ b/src/Monitor/Monitor.csproj
@@ -17,7 +17,7 @@
     <PackageTags>azure;powershell;clients;monitor</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -40,6 +40,10 @@
     <PackageReference Include="System.Security.SecureString" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/Monitor/Monitor.csproj
+++ b/src/Monitor/Monitor.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Network/Network.csproj
+++ b/src/Network/Network.csproj
@@ -17,7 +17,7 @@
     <PackageTags>azure;powershell;clients;network</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -52,6 +52,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/Network/Network.csproj
+++ b/src/Network/Network.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/PolicyInsights/PolicyInsights.csproj
+++ b/src/PolicyInsights/PolicyInsights.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/PolicyInsights/PolicyInsights.csproj
+++ b/src/PolicyInsights/PolicyInsights.csproj
@@ -17,7 +17,7 @@
     <PackageTags>azure;powershell;clients;policyInsights</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -33,5 +33,9 @@
     <AssemblyOriginatorKeyFile>..\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>TRACE;RELEASE;NETSTANDARD;SIGN</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+  </ItemGroup>
 
 </Project>

--- a/src/ResourceManager/ResourceManager.csproj
+++ b/src/ResourceManager/ResourceManager.csproj
@@ -20,7 +20,7 @@
     <PackageTags>azure;powershell;clients;resourcemanager</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -55,6 +55,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/ResourceManager/ResourceManager.csproj
+++ b/src/ResourceManager/ResourceManager.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Storage.Management/Storage.Management.csproj
+++ b/src/Storage.Management/Storage.Management.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Storage.Management/Storage.Management.csproj
+++ b/src/Storage.Management/Storage.Management.csproj
@@ -19,7 +19,7 @@
     <PackageTags>azure;powershell;clients;storage;management</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
     <PackageVersion>1.0.0-preview</PackageVersion>
@@ -60,6 +60,10 @@
     <EmbeddedResource Remove="Stack\Properties\Resources.resx" />
     <None Remove="Stack\MSSharedLibKey.snk" />
     <None Remove="Stack\packages.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -69,7 +69,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -20,7 +20,7 @@
     <PackageTags>azure;powershell;storage</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
     <NoPackageAnalysis>true</NoPackageAnalysis>
@@ -66,6 +66,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Authentication.Abstractions\Authentication.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/Strategies/Strategies.csproj
+++ b/src/Strategies/Strategies.csproj
@@ -17,7 +17,7 @@
     <PackageTags>azure;powershell;strategies</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
     <PackageVersion>1.0.0-preview</PackageVersion>
@@ -34,5 +34,9 @@
     <AssemblyOriginatorKeyFile>..\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>TRACE;RELEASE;NETSTANDARD;SIGN</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+  </ItemGroup>
 
 </Project>

--- a/src/Strategies/Strategies.csproj
+++ b/src/Strategies/Strategies.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Websites/Websites.csproj
+++ b/src/Websites/Websites.csproj
@@ -17,7 +17,7 @@
     <PackageTags>azure;powershell;clients;websites</PackageTags>
     <Authors>Microsoft Corporation</Authors>
     <Copyright>Copyright © Microsoft Corporation</Copyright>
-    <PackageLicenseUrl>https://aka.ms/azps-common-license</PackageLicenseUrl>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/Azure/azure-powershell-common</PackageProjectUrl>
     <PackageOutputPath>$(ProjectDir)..\..\artifacts\Package\$(Configuration)</PackageOutputPath>
   </PropertyGroup>
@@ -40,6 +40,10 @@
     <PackageReference Include="System.Security.SecureString" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 
 </Project>

--- a/src/Websites/Websites.csproj
+++ b/src/Websites/Websites.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="LICENSE.txt" Pack="true" Visible="false" PackagePath=""/>
+    <None Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The "PackageLicenseUrl" element in .csproj is deprecated since .net 15.9, it's changed to "PackageLicenseFile" using LINCENSE.txt in the repo instead.