### PR TITLE
Revert "add attestation endpoint and token audience required for authenticating with Azure Attestation tenants"

### DIFF
--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -49,9 +49,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 GraphEndpointResourceId = AzureEnvironmentConstants.AzureGraphEndpoint,
                 DataLakeEndpointResourceId = AzureEnvironmentConstants.AzureDataLakeServiceEndpointResourceId,
                 BatchEndpointResourceId = AzureEnvironmentConstants.BatchEndpointResourceId,
-                AdTenant = "Common",
-                AzureAttestationDnsSuffix = AzureEnvironmentConstants.AzureAttestationDnsSuffix,
-                AzureAttestationServiceEndpointResourceId = AzureEnvironmentConstants.AzureAttestationServiceEndpointResourceId
+                AdTenant = "Common"
             };
             azureCloud.SetProperty(ExtendedEndpoint.OperationalInsightsEndpoint, AzureEnvironmentConstants.AzureOperationalInsightsEndpoint);
             azureCloud.SetProperty(ExtendedEndpoint.OperationalInsightsEndpointResourceId, AzureEnvironmentConstants.AzureOperationalInsightsEndpointResourceId);
@@ -279,16 +277,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         public IDictionary<string, string> ExtendedProperties { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// The domain name suffix for Azure Attestation tensnts created in this environment
-        /// </summary>
-        public string AzureAttestationDnsSuffix { get; set; }
-
-        /// <summary>
-        /// The token audience required for communicating with the Azure Attestation service in this environment
-        /// </summary>
-        public string AzureAttestationServiceEndpointResourceId { get; set; }
-
-        /// <summary>
         /// A set of string constants for each of the known environment values - allows users to specify a particular kind of endpoint by name
         /// </summary>
         public static class Endpoint
@@ -311,9 +299,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = "AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix",
                 AzureDataLakeStoreFileSystemEndpointSuffix = "AzureDataLakeStoreFileSystemEndpointSuffix",
                 DataLakeEndpointResourceId = "DataLakeEndpointResourceId",
-                BatchEndpointResourceId = "BatchEndpointResourceId",
-                AzureAttestationServiceEndpointResourceId = "AzureAttestationServiceEndpointResourceId",
-                AzureAttestationDnsSuffix = "AzureAttestationDnsSuffix";
+                BatchEndpointResourceId = "BatchEndpointResourceId";
         }
 
         public static class ExtendedEndpoint

--- a/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
+++ b/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
@@ -171,15 +171,5 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         public const string ChinaAnalysisServicesEndpointResourceId = "https://region.asazure.chinacloudapi.cn";
         public const string USGovernmentAnalysisServicesEndpointResourceId = "https://region.asazure.usgovcloudapi.net";
         public const string GermanAnalysisServicesEndpointResourceId = "https://region.asazure.cloudapi.de";
-
-        /// <summary>
-        /// The domain name suffix for azure attestation tennats
-        /// </summary>
-        public const string AzureAttestationDnsSuffix = "attest.azure.net ";
-
-        /// <summary>
-        /// The token audience for authorizing Attestation requests
-        /// </summary>
-        public const string AzureAttestationServiceEndpointResourceId = "https://attest.azure.net";
     }
 }

--- a/src/Authentication.Abstractions/Extensions/AzureEnvironmentExtensions.cs
+++ b/src/Authentication.Abstractions/Extensions/AzureEnvironmentExtensions.cs
@@ -151,12 +151,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                     case AzureEnvironment.Endpoint.BatchEndpointResourceId:
                         propertyValue = environment.BatchEndpointResourceId;
                         break;
-                    case AzureEnvironment.Endpoint.AzureAttestationDnsSuffix:
-                        propertyValue = environment.AzureAttestationDnsSuffix;
-                        break;
-                    case AzureEnvironment.Endpoint.AzureAttestationServiceEndpointResourceId:
-                        propertyValue = environment.AzureAttestationServiceEndpointResourceId;
-                        break;
                     default:
                         // get property from the extended properties of the environment
                         propertyValue = environment.GetProperty(endpointName);
@@ -283,12 +277,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                     case AzureEnvironment.ExtendedEndpoint.AnalysisServicesEndpointResourceId:
                         environment.SetProperty(AzureEnvironment.ExtendedEndpoint.AnalysisServicesEndpointResourceId, propertyValue);
                         break;
-                    case AzureEnvironment.Endpoint.AzureAttestationDnsSuffix:
-                        environment.AzureAttestationDnsSuffix = propertyValue;
-                        break;
-                    case AzureEnvironment.Endpoint.AzureAttestationServiceEndpointResourceId:
-                        environment.AzureAttestationServiceEndpointResourceId = propertyValue;
-                        break;
                 }
             }
         }
@@ -323,10 +311,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 case AzureEnvironment.ExtendedEndpoint.AnalysisServicesEndpointSuffix:
                 case AzureEnvironment.ExtendedEndpoint.AnalysisServicesEndpointResourceId:
                     resource = AzureEnvironment.ExtendedEndpoint.AnalysisServicesEndpointResourceId;
-                    break;
-                case AzureEnvironment.Endpoint.AzureAttestationDnsSuffix:
-                case AzureEnvironment.Endpoint.AzureAttestationServiceEndpointResourceId:
-                    resource = AzureEnvironment.Endpoint.AzureAttestationServiceEndpointResourceId;
                     break;
                 default:
                     resource = AzureEnvironment.Endpoint.ActiveDirectoryServiceEndpointResourceId;
@@ -510,15 +494,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 {
                     environment.BatchEndpointResourceId = other.BatchEndpointResourceId;
                 }
-                if (other.IsEndpointSet(AzureEnvironment.Endpoint.AzureAttestationDnsSuffix))
-                {
-                    environment.AzureAttestationDnsSuffix = other.AzureAttestationDnsSuffix;
-                }
-                if (other.IsEndpointSet(AzureEnvironment.Endpoint.AzureAttestationServiceEndpointResourceId))
-                {
-                    environment.AzureAttestationServiceEndpointResourceId =
-                        other.AzureAttestationServiceEndpointResourceId;
-                }
 
                 environment.VersionProfiles.Clear();
                 foreach (var profile in other.VersionProfiles)
@@ -609,15 +584,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 if (other.IsEndpointSet(AzureEnvironment.Endpoint.DataLakeEndpointResourceId))
                 {
                     environment.DataLakeEndpointResourceId = other.DataLakeEndpointResourceId;
-                }
-                if (other.IsEndpointSet(AzureEnvironment.Endpoint.AzureAttestationDnsSuffix))
-                {
-                    environment.AzureAttestationDnsSuffix = other.AzureAttestationDnsSuffix;
-                }
-                if (other.IsEndpointSet(AzureEnvironment.Endpoint.AzureAttestationServiceEndpointResourceId))
-                {
-                    environment.AzureAttestationServiceEndpointResourceId =
-                        other.AzureAttestationServiceEndpointResourceId;
                 }
 
                 foreach (var profile in other.VersionProfiles)

--- a/src/Authentication.Abstractions/Interfaces/IAzureEnvironment.cs
+++ b/src/Authentication.Abstractions/Interfaces/IAzureEnvironment.cs
@@ -131,15 +131,5 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// The set of version profile s(service capabilities) supported
         /// </summary>
         IList<string> VersionProfiles { get; }
-
-        /// <summary>
-        /// The domain name suffix for Azure Attestation tenants
-        /// </summary>
-        string AzureAttestationDnsSuffix { get; set; }
-
-        /// <summary>
-        /// The token audience required for authenticating with Azure Attestation tenants
-        /// </summary>
-        string AzureAttestationServiceEndpointResourceId { get; set; }
     }
 }


### PR DESCRIPTION
Reverts Azure/azure-powershell-common#156

This PR updates the IAzureEnvironment interface in our base abstractions.  This is a binary breaking change that will cause issues with any version of a module depennding on the previous abstraction.

When we add new endpoints, we add them in the Extensions dictionary, not to the interface itself, like this: https://github.com/Azure/azure-powershell-common/blob/master/src/Authentication.Abstractions/AzureEnvironment.cs#L56

We should have noticed the problem earlier. Sorry for the inconvenience @shleiAmy , please re-submit your PR.
cc @markcowl 