### PR TITLE
Add az version, time, and subscription id to client telemetry

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -27,6 +27,8 @@ using System.Linq;
 using System.Management.Automation;
 using System.Text;
 using System.Collections.Generic;
+using System.Management.Automation.Runspaces;
+using System.Collections.ObjectModel;
 
 namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 {
@@ -859,6 +861,51 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             }
 
             return false;
+        }
+        //The latest version of Az Wrapper in local. It will be loaded in runtime when the first cmdlet is executed.
+        //If there is no Az module, the version is "0.0.0"
+        public static string AzVersion { set; get; }
+
+        //Initialized once AzVersion is loadded.
+        //Format: AzurePowershell/Az0.0.0;%AZUREPS_HOST_ENVIROMENT%
+        public static string UserAgent { set; get; }
+
+        protected string LoadAzVersion()
+        {
+            Version latestAz = new Version("0.0.0");
+            string latestSuffix = "";
+            using (var powershell = System.Management.Automation.PowerShell.Create())
+            {
+                powershell.Runspace = RunspaceFactory.CreateRunspace(this.Host);
+                powershell.AddCommand("Get-Module");
+                powershell.AddParameter("Name", "Az");
+                powershell.AddParameter("ListAvailable", true);
+                powershell.Runspace.Open();
+                Collection<PSObject> outputs = powershell.Invoke();
+                foreach (PSObject obj in outputs)
+                {
+                    string psVersion = obj.Properties["Version"].Value.ToString();
+                    int pos = psVersion.IndexOf('-');
+                    string currentSuffix = (pos == -1 || pos == psVersion.Length - 1) ? "" : psVersion.Substring(pos + 1);
+                    Version currentAz = (pos == -1) ? new Version(psVersion) : new Version(psVersion.Substring(0, pos));
+                    if (currentAz > latestAz)
+                    {
+                        latestAz = currentAz;
+                        latestSuffix = currentSuffix;
+                    }
+                    else if (currentAz == latestAz)
+                    {
+                        latestSuffix = String.Compare(latestSuffix, currentSuffix) > 0 ? latestSuffix : currentSuffix;
+                    }
+                }
+            }
+            string ret = latestAz.ToString();
+            if (!String.IsNullOrEmpty(latestSuffix))
+            {
+                ret += "-" + latestSuffix;
+            }
+            WriteDebug(string.Format("Sought all Az modules and got latest version {0}", ret));
+            return ret;
         }
     }
 }

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -15,20 +15,18 @@
 using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Commands.Common.Authentication;
 using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
-using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
 using Microsoft.Azure.ServiceManagement.Common.Models;
 using Microsoft.WindowsAzure.Commands.Common;
-using Microsoft.WindowsAzure.Commands.Utilities.Common;
+using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
-using System.Text;
-using System.Collections.Generic;
 using System.Management.Automation.Runspaces;
-using System.Collections.ObjectModel;
+using System.Text;
 
 namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 {

--- a/src/Common/AzurePowerShell.cs
+++ b/src/Common/AzurePowerShell.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.IO;
-using System.Net.Http.Headers;
 
 namespace Microsoft.WindowsAzure.Commands.Common
 {

--- a/src/Common/AzurePowerShell.cs
+++ b/src/Common/AzurePowerShell.cs
@@ -22,7 +22,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
     {
         public const string AssemblyCompany = "Microsoft";
 
-        public const string AssemblyProduct = "Microsoft Azure Powershell";
+        public const string AssemblyProduct = "Microsoft Azure PowerShell";
 
         public const string AssemblyCopyright = "Copyright © Microsoft";
 
@@ -37,10 +37,6 @@ namespace Microsoft.WindowsAzure.Commands.Common
         public const string OldProfileFileBackup = "WindowsAzureProfile.xml.bak";
 
         public const string TokenCacheFile = "TokenCache.dat";
-
-        public static ProductInfoHeaderValue UserAgentValue = new ProductInfoHeaderValue(
-            "AzurePowershell",
-            string.Format("Az{0}", AzurePowerShell.AssemblyVersion));
 
         public static string ProfileDirectory = Path.Combine(
 #if NETSTANDARD

--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -346,13 +346,6 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
             }
         }
 
-        protected override void LogCmdletEndInvocationInfo()
-        {
-            base.LogCmdletEndInvocationInfo();
-            string message = string.Format("{0} end processing.", this.GetType().Name);
-            WriteDebugWithTimestamp(message);
-        }
-
         protected override void SetupDebuggingTraces()
         {
             ServiceClientTracing.IsEnabled = true;

--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -300,9 +300,9 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
             {
                 AzVersion = this.LoadAzVersion();
                 UserAgent = new ProductInfoHeaderValue("AzurePowershell", string.Format("Az{0}", AzVersion)).ToString();
-                string HostEnv = Environment.GetEnvironmentVariable("AZUREPS_HOST_ENVIRONMENT");
-                if (!String.IsNullOrWhiteSpace(HostEnv))
-                    UserAgent += string.Format(";{0}", HostEnv.Trim());
+                string hostEnv = Environment.GetEnvironmentVariable("AZUREPS_HOST_ENVIRONMENT");
+                if (!String.IsNullOrWhiteSpace(hostEnv))
+                    UserAgent += string.Format(";{0}", hostEnv.Trim());
             }
             _qosEvent.AzVersion = AzVersion;
             _qosEvent.UserAgent = UserAgent;


### PR DESCRIPTION
Changes around customer data in client telemetry:

1. Fetch and add az version to user agent
2. Add start time, end time, and effective execution duration
3. Add AZUREPS_HOST_ENVIRONMENT to user agent
4. Add subscription id and tenant id

A minor change is to remove exception message if cmdlet has no exception.
Another minor change is fixing issue https://github.com/Azure/azure-powershell/issues/10887