### PR TITLE
Revert "Upgrade application insight SDK version to 2.12.0 (#189) (#190)"

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using Microsoft.ApplicationInsights;
 using Microsoft.Azure.Commands.Common.Authentication;
 using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
 using Microsoft.Azure.ServiceManagement.Common.Models;
@@ -19,10 +20,12 @@ using Microsoft.WindowsAzure.Commands.Common;
 using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using System.Management.Automation.Runspaces;
 using System.Text;
 
 namespace Microsoft.WindowsAzure.Commands.Utilities.Common
@@ -335,7 +338,6 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             AzureSession.Instance.ClientFactory.RemoveUserAgent(ModuleName);
             AzureSession.Instance.ClientFactory.RemoveHandler(typeof(CmdletInfoHandler));
         }
-
         /// <summary>
         /// Cmdlet begin process. Write to logs, setup Http Tracing and initialize profile
         /// </summary>
@@ -350,7 +352,10 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                 if (_metricHelper == null)
                 {
                     _metricHelper = new MetricHelper(profile);
-                    _metricHelper.AddDefaultTelemetryClient();
+                    _metricHelper.AddTelemetryClient(new TelemetryClient
+                    {
+                        InstrumentationKey = "7df6ff70-8353-4672-80d6-568517fed090"
+                    });
                 }
             }
 

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.12.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -24,6 +24,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Management.Automation.Host;
+using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -117,17 +118,13 @@ namespace Microsoft.WindowsAzure.Commands.Common
             _profile = profile;
         }
 
-        private TelemetryConfiguration telemetryConfiguration;
-
         public MetricHelper(INetworkHelper network)
         {
             _networkHelper = network;
-            telemetryConfiguration = new TelemetryConfiguration();
-            telemetryConfiguration.InstrumentationKey = "7df6ff70-8353-4672-80d6-568517fed090";
 #if DEBUG
             if (TestMockSupport.RunningMocked)
             {
-                telemetryConfiguration.DisableTelemetry = true;
+                TelemetryConfiguration.Active.DisableTelemetry = true;
             }
 #endif
         }
@@ -159,12 +156,6 @@ namespace Microsoft.WindowsAzure.Commands.Common
                 _threadSafeTelemetryClients = new List<TelemetryClient>(_telemetryClients);
             }
         }
-
-        public void AddDefaultTelemetryClient()
-        {
-            AddTelemetryClient(new TelemetryClient(telemetryConfiguration));
-        }
-
 
         public void LogQoSEvent(AzurePSQoSEvent qos, bool isUsageMetricEnabled, bool isErrorMetricEnabled)
         {


### PR DESCRIPTION
This reverts commit 0bfa2f3f6e015ea9492b2e33b427adb0de2f76f7. because OOM issue is found when we use ApplicationInsight SDK 2.12.0. We need to upgrade it later once issue is resolved.