### PR TITLE
Adjust value from ARM endpoint due to compatibility

### DIFF
--- a/src/Authentication.Abstractions.Test/Authentication.Abstractions.Test.csproj
+++ b/src/Authentication.Abstractions.Test/Authentication.Abstractions.Test.csproj
@@ -19,10 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="TestData\BadArmResponse.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestData\GoodArmResponse.json">
+    <None Update="TestData\*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/src/Authentication.Abstractions.Test/AzureEnvironmentTests.cs
+++ b/src/Authentication.Abstractions.Test/AzureEnvironmentTests.cs
@@ -14,7 +14,6 @@
 
 using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Authentication.Abstractions.Test
@@ -22,7 +21,6 @@ namespace Authentication.Abstractions.Test
     public class AzureEnvironmentTests
     {
         private const string ArmMetadataEnvVariable = "ARM_CLOUD_METADATA_URL";
-        readonly IDictionary<string, AzureEnvironment> hardCodedEnvironments = AzureEnvironment.PublicEnvironments;
 
         [Fact]
         public void TestArmAndNonArmBasedCloudMetadataInit()
@@ -35,6 +33,22 @@ namespace Authentication.Abstractions.Test
             foreach (var env in armEnvironments.Values)
             {
                 Assert.Equal(AzureEnvironment.TypeDiscovered, env.Type);
+            }
+        }
+
+        [Fact]
+        public void TestArmCloudMetadata20190501Init()
+        {
+            Environment.SetEnvironmentVariable(ArmMetadataEnvVariable, @"TestData\ArmResponse2019-05-01.json");
+            var armEnvironments = AzureEnvironment.InitializeBuiltInEnvironments(null, httpOperations: TestOperationsFactory.Create().GetHttpOperations());
+
+            // Check all discovered environments are loaded.
+            Assert.Equal(4, armEnvironments.Count);
+            foreach (var env in armEnvironments.Values)
+            {
+                Assert.Equal(AzureEnvironment.TypeDiscovered, env.Type);
+                Assert.EndsWith("/", env.ServiceManagementUrl);
+                Assert.StartsWith(".", env.SqlDatabaseDnsSuffix);
             }
         }
 

--- a/src/Authentication.Abstractions.Test/TestData/ArmResponse2019-05-01.json
+++ b/src/Authentication.Abstractions.Test/TestData/ArmResponse2019-05-01.json
@@ -1,0 +1,116 @@
+[
+  {
+    "portal": "https://portal.azure.com",
+    "authentication": {
+      "loginEndpoint": "https://login.windows.net/",
+      "audiences": [
+        "https://management.core.windows.net/",
+        "https://management.azure.com/"
+      ],
+      "tenant": "common",
+      "identityProvider": "AAD"
+    },
+    "media": "https://rest.media.azure.net",
+    "graphAudience": "https://graph.windows.net/",
+    "graph": "https://graph.windows.net/",
+    "name": "AzureCloud",
+    "suffixes": {
+      "azureDataLakeStoreFileSystem": "azuredatalakestore.net",
+      "acrLoginServer": "azurecr.io",
+      "sqlServerHostname": "database.windows.net",
+      "azureDataLakeAnalyticsCatalogAndJob": "azuredatalakeanalytics.net",
+      "keyVaultDns": "vault.azure.net",
+      "storage": "core.windows.net",
+      "azureFrontDoorEndpointSuffix": "azurefd.net"
+    },
+    "batch": "https://batch.core.windows.net/",
+    "resourceManager": "https://management.azure.com/",
+    "vmImageAliasDoc": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
+    "activeDirectoryDataLake": "https://datalake.azure.net/",
+    "sqlManagement": "https://management.core.windows.net:8443/",
+    "gallery": "https://gallery.azure.com/"
+  },
+  {
+    "portal": "https://portal.azure.cn",
+    "authentication": {
+      "loginEndpoint": "https://login.chinacloudapi.cn",
+      "audiences": [
+        "https://management.core.chinacloudapi.cn",
+        "https://management.chinacloudapi.cn"
+      ],
+      "tenant": "common",
+      "identityProvider": "AAD"
+    },
+    "media": "https://rest.media.chinacloudapi.cn",
+    "graphAudience": "https://graph.chinacloudapi.cn",
+    "graph": "https://graph.chinacloudapi.cn",
+    "name": "AzureChinaCloud",
+    "suffixes": {
+      "acrLoginServer": "azurecr.cn",
+      "sqlServerHostname": "database.chinacloudapi.cn",
+      "keyVaultDns": "vault.azure.cn",
+      "storage": "core.chinacloudapi.cn",
+      "azureFrontDoorEndpointSuffix": ""
+    },
+    "batch": "https://batch.chinacloudapi.cn",
+    "resourceManager": "https://management.chinacloudapi.cn",
+    "vmImageAliasDoc": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
+    "sqlManagement": "https://management.core.chinacloudapi.cn:8443",
+    "gallery": "https://gallery.chinacloudapi.cn"
+  },
+  {
+    "portal": "https://portal.azure.us",
+    "authentication": {
+      "loginEndpoint": "https://login.microsoftonline.us",
+      "audiences": [
+        "https://management.core.usgovcloudapi.net",
+        "https://management.usgovcloudapi.net"
+      ],
+      "tenant": "common",
+      "identityProvider": "AAD"
+    },
+    "media": "https://rest.media.usgovcloudapi.net",
+    "graphAudience": "https://graph.windows.net",
+    "graph": "https://graph.windows.net",
+    "name": "AzureUSGovernment",
+    "suffixes": {
+      "acrLoginServer": "azurecr.us",
+      "sqlServerHostname": "database.usgovcloudapi.net",
+      "keyVaultDns": "vault.usgovcloudapi.net",
+      "storage": "core.usgovcloudapi.net",
+      "azureFrontDoorEndpointSuffix": ""
+    },
+    "batch": "https://batch.core.usgovcloudapi.net",
+    "resourceManager": "https://management.usgovcloudapi.net",
+    "vmImageAliasDoc": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
+    "sqlManagement": "https://management.core.usgovcloudapi.net:8443",
+    "gallery": "https://gallery.usgovcloudapi.net"
+  },
+  {
+    "portal": "https://portal.microsoftazure.de",
+    "authentication": {
+      "loginEndpoint": "https://login.microsoftonline.de",
+      "audiences": [
+        "https://management.core.cloudapi.de",
+        "https://management.microsoftazure.de"
+      ],
+      "tenant": "common",
+      "identityProvider": "AAD"
+    },
+    "media": "https://rest.media.cloudapi.de",
+    "graphAudience": "https://graph.cloudapi.de",
+    "graph": "https://graph.cloudapi.de",
+    "name": "AzureGermanCloud",
+    "suffixes": {
+      "sqlServerHostname": "database.cloudapi.de",
+      "keyVaultDns": "vault.microsoftazure.de",
+      "storage": "core.cloudapi.de",
+      "azureFrontDoorEndpointSuffix": ""
+    },
+    "batch": "https://batch.cloudapi.de",
+    "resourceManager": "https://management.microsoftazure.de",
+    "vmImageAliasDoc": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
+    "sqlManagement": "https://management.core.cloudapi.de:8443",
+    "gallery": "https://gallery.cloudapi.de"
+  }
+]

--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -292,6 +292,19 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 AdTenant = armMetadata.Authentication.Tenant
             };
 
+            // There are mismatches between metadata built in Azure PowerShell/CLI and from ARM endpoint. 
+            // Considering compatibility, below hard coded logic accommodates those mismatches
+            // SqlDatabaseDnsSuffix requires value leading with period
+            // ServiceManagementUrl as audience needs to end with slash
+            if(azureEnvironment.SqlDatabaseDnsSuffix != null && !azureEnvironment.SqlDatabaseDnsSuffix.StartsWith("."))
+            {
+                azureEnvironment.SqlDatabaseDnsSuffix = "." + azureEnvironment.SqlDatabaseDnsSuffix;
+            }
+            if (azureEnvironment.ServiceManagementUrl != null && !azureEnvironment.ServiceManagementUrl.EndsWith("/"))
+            {
+                azureEnvironment.ServiceManagementUrl += "/";
+            }
+
             return azureEnvironment;
         }
 


### PR DESCRIPTION
SqlDatabaseDnsSuffix needs to lead with period character
ServiceManagementUrl needs to end with slash

ARM team cannot change their payload because it may impact other clients. Above logic is added when AzureEnvironment is imported from discovery endpoint. 