### PR TITLE
Add correct module name and version from MyInvocation

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -571,8 +571,6 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             _qosEvent = new AzurePSQoSEvent()
             {
                 CommandName = commandAlias,
-                ModuleName = this.GetType().Assembly.GetName().Name,
-                ModuleVersion = this.GetType().Assembly.GetName().Version.ToString(),
                 ClientRequestId = this._clientRequestId,
                 SessionId = _sessionId,
                 IsSuccess = true,
@@ -589,6 +587,17 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             }
             _qosEvent.AzVersion = AzVersion;
             _qosEvent.UserAgent = UserAgent;
+
+            if (this.MyInvocation != null && this.MyInvocation.MyCommand != null)
+            {
+                _qosEvent.ModuleName = this.MyInvocation.MyCommand.ModuleName;
+                _qosEvent.ModuleVersion = this.MyInvocation.MyCommand.Version.ToString();
+            }
+            else
+            {
+                _qosEvent.ModuleName = this.GetType().Assembly.GetName().Name;
+                _qosEvent.ModuleVersion = this.GetType().Assembly.GetName().Version.ToString();
+            }
 
             if (this.MyInvocation != null && !string.IsNullOrWhiteSpace(this.MyInvocation.InvocationName))
             {

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -562,15 +562,8 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 
         protected virtual void InitializeQosEvent()
         {
-            var commandAlias = this.GetType().Name;
-            if (this.MyInvocation != null && this.MyInvocation.MyCommand != null)
-            {
-                commandAlias = this.MyInvocation.MyCommand.Name;
-            }
-
             _qosEvent = new AzurePSQoSEvent()
             {
-                CommandName = commandAlias,
                 ClientRequestId = this._clientRequestId,
                 SessionId = _sessionId,
                 IsSuccess = true,
@@ -590,11 +583,13 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 
             if (this.MyInvocation != null && this.MyInvocation.MyCommand != null)
             {
+                _qosEvent.CommandName = this.MyInvocation.MyCommand.Name;
                 _qosEvent.ModuleName = this.MyInvocation.MyCommand.ModuleName;
                 _qosEvent.ModuleVersion = this.MyInvocation.MyCommand.Version.ToString();
             }
             else
             {
+                _qosEvent.CommandName = this.GetType().Name;
                 _qosEvent.ModuleName = this.GetType().Assembly.GetName().Name;
                 _qosEvent.ModuleVersion = this.GetType().Assembly.GetName().Version.ToString();
             }


### PR DESCRIPTION
Get module name from assembly is incorrect for binary cmdlet. It should be fetched from MyInvocation properties.
Adjust cmdlet name fetch logic together