### PR TITLE
Set X509KeyStorageFlags.PersistKeySet flag explicitly

### DIFF
--- a/src/Authentication.Abstractions/DiskDataStore.cs
+++ b/src/Authentication.Abstractions/DiskDataStore.cs
@@ -223,8 +223,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
             X509StoreWrapper(StoreName.My, StoreLocation.CurrentUser, (store) =>
             {
                 store.Open(OpenFlags.ReadWrite);
-                X509Certificate2 storedCertificate = new X509Certificate2(certificate.RawData, string.Empty);
-                store.Add(storedCertificate);
+                store.Add(certificate);
             });
         }
 

--- a/src/Authentication.Abstractions/DiskDataStore.cs
+++ b/src/Authentication.Abstractions/DiskDataStore.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
             X509StoreWrapper(StoreName.My, StoreLocation.CurrentUser, (store) =>
             {
                 store.Open(OpenFlags.ReadWrite);
-                X509Certificate2 storedCertificate = new X509Certificate2(certificate.RawData, string.Empty, X509KeyStorageFlags.PersistKeySet);
+                X509Certificate2 storedCertificate = new X509Certificate2(certificate.RawData, string.Empty);
                 store.Add(storedCertificate);
             });
         }

--- a/src/Authentication.Abstractions/DiskDataStore.cs
+++ b/src/Authentication.Abstractions/DiskDataStore.cs
@@ -223,7 +223,8 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
             X509StoreWrapper(StoreName.My, StoreLocation.CurrentUser, (store) =>
             {
                 store.Open(OpenFlags.ReadWrite);
-                store.Add(certificate);
+                X509Certificate2 storedCertificate = new X509Certificate2(certificate.RawData, string.Empty, X509KeyStorageFlags.PersistKeySet);
+                store.Add(storedCertificate);
             });
         }
 

--- a/src/Authentication.Abstractions/Properties/AssemblyInfo.cs
+++ b/src/Authentication.Abstractions/Properties/AssemblyInfo.cs
@@ -43,5 +43,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.1")]
+[assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.1")]

--- a/src/Common/Properties/AssemblyInfo.cs
+++ b/src/Common/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]
 [assembly: Guid("4f3ab2e4-cc7a-43ac-bb15-f481fcf94d58")]
-[assembly: AssemblyVersion("4.0.0.1")]
+[assembly: AssemblyVersion("4.0.0.0")]
 [assembly: AssemblyFileVersion("4.0.0.1")]
 #if SIGN
 [assembly: InternalsVisibleTo("Microsoft.WindowsAzure.Commands, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/ServiceManagement/Properties/AssemblyInfo.cs
+++ b/src/ServiceManagement/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: CLSCompliant(false)]
 [assembly: Guid("4f3ab2e4-cc7a-43ac-bb15-f481fcf94d58")]
-[assembly: AssemblyVersion("5.3.0.1")]
+[assembly: AssemblyVersion("5.3.0.0")]
 [assembly: AssemblyFileVersion("5.3.0.1")]
 #if SIGN
 [assembly: InternalsVisibleTo("Microsoft.WindowsAzure.Commands, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/ServiceManagement/PublishSettingsImporter.cs
+++ b/src/ServiceManagement/PublishSettingsImporter.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.ServiceManagemenet.Common
                 certificateString = profile.ManagementCertificate;
             }
 
-            X509Certificate2 certificate = new X509Certificate2(Convert.FromBase64String(certificateString), string.Empty);
+            X509Certificate2 certificate = new X509Certificate2(Convert.FromBase64String(certificateString), string.Empty, X509KeyStorageFlags.PersistKeySet);
             AzureSession.Instance.DataStore.AddCertificate(certificate);
 
             return certificate;


### PR DESCRIPTION
Dotnet had a bug that did not remove temporary private keys (non-persistent) for certificates. September Rollup fixed this bug. As the result, client is blocked because private keys are removed during importing publish setting because its code uses default key setting. The correct way is we should set PersistKeySet explicitly

Details is from https://docs.microsoft.com/en-us/troubleshoot/dotnet/framework/install-pfx-file-using-x509certificate