### PR TITLE
Use DNS suffix as resource id when it is not provided

### DIFF
--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -303,9 +303,10 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 GalleryUrl = armMetadata.Gallery,
                 SqlDatabaseDnsSuffix = armMetadata.Suffixes.SqlServerHostname,
                 GraphUrl = armMetadata.Graph,
+                //TODO, ARM endpoint doesn't have TrafficManagerDnsSuffix
                 TrafficManagerDnsSuffix = GetTrafficManagerDnsSuffix(armMetadata.Name),
                 AzureKeyVaultDnsSuffix = armMetadata.Suffixes.KeyVaultDns,
-                AzureKeyVaultServiceEndpointResourceId = GetKeyVaultServiceEndpointResourceId(armMetadata.Name),
+                AzureKeyVaultServiceEndpointResourceId = $"https://{armMetadata.Suffixes.KeyVaultDns}",
                 AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = armMetadata.Suffixes.AzureDataLakeAnalyticsCatalogAndJob,
                 AzureDataLakeStoreFileSystemEndpointSuffix = armMetadata.Suffixes.AzureDataLakeStoreFileSystem,
                 DataLakeEndpointResourceId = armMetadata.ActiveDirectoryDataLake,

--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -306,8 +306,8 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 //TODO, ARM endpoint doesn't have TrafficManagerDnsSuffix
                 TrafficManagerDnsSuffix = GetTrafficManagerDnsSuffix(armMetadata.Name),
                 AzureKeyVaultDnsSuffix = armMetadata.Suffixes.KeyVaultDns,
-                //ARM endpoint doens't provide KeyVault service resource id. We reuse the value of KeyVaultDns
-                AzureKeyVaultServiceEndpointResourceId = $"https://{armMetadata.Suffixes.KeyVaultDns}",
+                //Default ARM endpoint doens't provide KeyVault service resource id. Keep it here just in case.
+                AzureKeyVaultServiceEndpointResourceId = GetKeyVaultServiceEndpointResourceId(armMetadata.Name),
                 AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = armMetadata.Suffixes.AzureDataLakeAnalyticsCatalogAndJob,
                 AzureDataLakeStoreFileSystemEndpointSuffix = armMetadata.Suffixes.AzureDataLakeStoreFileSystem,
                 DataLakeEndpointResourceId = armMetadata.ActiveDirectoryDataLake,
@@ -316,6 +316,12 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 AdTenant = armMetadata.Authentication.Tenant,
                 ContainerRegistryEndpointSuffix = armMetadata.Suffixes.AcrLoginServer
             };
+
+            //We reuse the value of KeyVaultDns
+            if (string.IsNullOrEmpty(azureEnvironment.AzureKeyVaultServiceEndpointResourceId))
+            {
+                azureEnvironment.AzureKeyVaultServiceEndpointResourceId = $"https://{azureEnvironment.AzureKeyVaultDnsSuffix}";
+            }
 
             // There are mismatches between metadata built in Azure PowerShell/CLI and from ARM endpoint.
             // Considering compatibility, below hard coded logic accommodates those mismatches

--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -306,6 +306,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 //TODO, ARM endpoint doesn't have TrafficManagerDnsSuffix
                 TrafficManagerDnsSuffix = GetTrafficManagerDnsSuffix(armMetadata.Name),
                 AzureKeyVaultDnsSuffix = armMetadata.Suffixes.KeyVaultDns,
+                //ARM endpoint doens't provide KeyVault service resource id. We reuse the value of KeyVaultDns
                 AzureKeyVaultServiceEndpointResourceId = $"https://{armMetadata.Suffixes.KeyVaultDns}",
                 AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = armMetadata.Suffixes.AzureDataLakeAnalyticsCatalogAndJob,
                 AzureDataLakeStoreFileSystemEndpointSuffix = armMetadata.Suffixes.AzureDataLakeStoreFileSystem,


### PR DESCRIPTION
If ResourceID is not provided by ARM endpoint, we assume it is consistent with DNS suffix.