### PR TITLE
Improve exception message in telemetry

### DIFF
--- a/src/Authentication.Abstractions/Interfaces/IContainsAzPSErrorData.cs
+++ b/src/Authentication.Abstractions/Interfaces/IContainsAzPSErrorData.cs
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.Azure.Commands.Common
 {
     /// <summary>
@@ -44,6 +46,7 @@ namespace Microsoft.Azure.Commands.Common
     /// <summary>
     /// Represent Error Kind
     /// </summary>
+    [Serializable]
     public class ErrorKind
     {
         public string Value { get; private set; }

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -358,9 +358,9 @@ namespace Microsoft.WindowsAzure.Commands.Common
                         // For the time being, we consider ResourceNotFound and ResourceGroupNotFound as user's input error. 
                         // We are considering if ResourceNotFound should be false positive error.
                         if (("ResourceNotFound".Equals(cloudErrorCode) || "ResourceGroupNotFound".Equals(cloudErrorCode))
-                            && existingErrorKind != ErrorKind.FalseError)
+                            && !ErrorKind.FalseError.ToString().Equals(existingErrorKind))
                         {
-                            qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey] = ErrorKind.UserError;
+                            qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey] = ErrorKind.UserError.ToString();
                         }
                     }
 
@@ -390,8 +390,8 @@ namespace Microsoft.WindowsAzure.Commands.Common
 
                 if (!qos.IsSuccess && qos.Exception?.Data?.Contains(AzurePSErrorDataKeys.ErrorKindKey) == true)
                 {
-                    eventProperties["pebcak"] = (qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey] == ErrorKind.UserError).ToString();
-                    if (qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey] == ErrorKind.FalseError)
+                    eventProperties["pebcak"] = (ErrorKind.UserError.ToString().Equals(qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey])).ToString();
+                    if (ErrorKind.FalseError.ToString().Equals(qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey]))
                     {
                         eventProperties["IsSuccess"] = true.ToString();
                     }
@@ -566,7 +566,7 @@ public class AzurePSQoSEvent
             "AzureQoSEvent: CommandName - {0}; IsSuccess - {1}; Duration - {2}", CommandName, IsSuccess, Duration);
         if (Exception != null)
         {
-            ret = $"{ret}; Exception - {Exception};";
+            ret = $"{ret}; Exception - {Exception.Message};";
         }
         return ret;
     }

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -358,9 +358,9 @@ namespace Microsoft.WindowsAzure.Commands.Common
                         // For the time being, we consider ResourceNotFound and ResourceGroupNotFound as user's input error. 
                         // We are considering if ResourceNotFound should be false positive error.
                         if (("ResourceNotFound".Equals(cloudErrorCode) || "ResourceGroupNotFound".Equals(cloudErrorCode))
-                            && !ErrorKind.FalseError.ToString().Equals(existingErrorKind))
+                            && existingErrorKind != ErrorKind.FalseError)
                         {
-                            qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey] = ErrorKind.UserError.ToString();
+                            qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey] = ErrorKind.UserError;
                         }
                     }
 
@@ -390,8 +390,8 @@ namespace Microsoft.WindowsAzure.Commands.Common
 
                 if (!qos.IsSuccess && qos.Exception?.Data?.Contains(AzurePSErrorDataKeys.ErrorKindKey) == true)
                 {
-                    eventProperties["pebcak"] = (ErrorKind.UserError.ToString().Equals(qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey])).ToString();
-                    if (ErrorKind.FalseError.ToString().Equals(qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey]))
+                    eventProperties["pebcak"] = (qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey] == ErrorKind.UserError).ToString();
+                    if (qos.Exception.Data[AzurePSErrorDataKeys.ErrorKindKey] == ErrorKind.FalseError)
                     {
                         eventProperties["IsSuccess"] = true.ToString();
                     }


### PR DESCRIPTION
Couple improvements
* The value being set into exception.data should explicitly parse to string on .NET Framework.
* Shorten exception and just show its message during debug mode

The issue is https://github.com/Azure/azure-powershell/issues/14556