### PR TITLE
Add endpoint of OperationalInsights in ChinaCloud

### DIFF
--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -254,6 +254,8 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
 
             if (azureEnvironments.ContainsKey(EnvironmentName.AzureChinaCloud))
             {
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpoint, AzureEnvironmentConstants.ChinaOperationalInsightsEndpoint);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpointResourceId, AzureEnvironmentConstants.ChinaOperationalInsightsEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointSuffix, AzureEnvironmentConstants.ChinaAnalysisServicesEndpointSuffix);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.ChinaAnalysisServicesEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, AzureEnvironmentConstants.ChinaSynapseAnalyticsEndpointSuffix);

--- a/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
+++ b/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
@@ -140,12 +140,14 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// The token audience for Log Analytics Queries
         /// </summary>
         public const string AzureOperationalInsightsEndpointResourceId = "https://api.loganalytics.io";
+        public const string ChinaOperationalInsightsEndpointResourceId = "https://api.loganalytics.azure.cn";
         public const string USGovernmentOperationalInsightsEndpointResourceId = "https://api.loganalytics.us";
 
         /// <summary>
         /// The endpoint URI for Log Analytics Queries
         /// </summary>
         public const string AzureOperationalInsightsEndpoint = "https://api.loganalytics.io/v1";
+        public const string ChinaOperationalInsightsEndpoint = "https://api.loganalytics.azure.cn/v1";
         public const string USGovernmentOperationalInsightsEndpoint = "https://api.loganalytics.us/v1";
 
         /// <summary>


### PR DESCRIPTION
OperationalInsights supports ChinaCloud now. Add endpoint to built-in environment.