### PR TITLE
Fixed typo in environement contants

### DIFF
--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.ChinaAnalysisServicesEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, AzureEnvironmentConstants.ChinaSynapseAnalyticsEndpointSuffix);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.ChinaSynapseAnalyticsEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.ChineManagedHsmServiceEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.ChinaManagedHsmServiceEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointSuffix, AzureEnvironmentConstants.ChinaManagedHsmDnsSuffix);
             }
 

--- a/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
+++ b/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// The token audience for authorizing managed hsm requests
         /// </summary>
         public const string AzureManagedHsmServiceEndpointResourceId = "https://managedhsm.azure.net";
-        public const string ChineManagedHsmServiceEndpointResourceId = "https://managedhsm.azure.cn";
+        public const string ChinaManagedHsmServiceEndpointResourceId = "https://managedhsm.azure.cn";
         public const string USGovernmeneManagedHsmServiceEndpointResourceId = "https://managedhsm.usgovcloudapi.net";
         public const string GermanAzureManagedHsmServiceEndpointResourceId = "https://managedhsm.microsoftazure.de";
 


### PR DESCRIPTION
Fixed 2 typos in AzureEnvironment and AzureEnvironmentConstants
(no need for a new common build)