### PR TITLE
Fix script of getting PowerShell version

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -1018,8 +1018,12 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
         {
             try
             {
-                var outputs = this.ExecuteScript<string>("$Host.Runspace.Version.ToString()");
-                return outputs[0];
+                var outputs = this.ExecuteScript<PSObject>("$Host.Runspace.Version");
+                foreach (PSObject obj in outputs)
+                {
+                    string psVersion = obj.ToString();
+                    return string.IsNullOrWhiteSpace(psVersion) ? DEFAULT_PSVERSION: psVersion;
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Fix one issue in https://github.com/Azure/azure-powershell-common/pull/278

ToString() in `$Host.Runspace.Version.ToString()` leads script error when PowerShell runspace has no version.
