### PR TITLE
Enable custom subscription ID by attribute

### DIFF
--- a/src/Authentication.Abstractions.Test/ContextUnitTests.cs
+++ b/src/Authentication.Abstractions.Test/ContextUnitTests.cs
@@ -1,0 +1,80 @@
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
+using Xunit;
+
+namespace Authentication.Abstractions.Test
+{
+    public class ContextUnitTests
+    {
+        [Fact]
+        public void TestDeepCopy()
+        {
+            IAzureSubscription subscription = new AzureSubscription()
+            {
+                Id = "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD",
+                Name = "my sub",
+                State = "my state",
+            };
+            const string SubHomeTenant = "my home tenant";
+            subscription.SetHomeTenant(SubHomeTenant);
+
+            IAzureAccount account = new AzureAccount()
+            {
+                Id = "someone@somewhere.com",
+                Type = "User"
+            };
+
+            IAzureEnvironment environment = new AzureEnvironment()
+            {
+                Name = "my environment"
+            };
+            IAzureTenant tenant = new AzureTenant()
+            {
+                Id = "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD"
+            };
+            IAzureContext original = new AzureContext(subscription, account, environment, tenant);
+            const string PropertyKey = "customPropertyKey";
+            const string PropertyValue = "customPropertyValue";
+            original.SetProperty(PropertyKey, PropertyValue);
+
+            IAzureContext clone = original.DeepCopy();
+
+            // references are not equal
+            Assert.False(ReferenceEquals(original, clone));
+            Assert.False(ReferenceEquals(original.Subscription, clone.Subscription));
+            Assert.False(ReferenceEquals(original.Account, clone.Account));
+            Assert.False(ReferenceEquals(original.Environment, clone.Environment));
+            Assert.False(ReferenceEquals(original.Tenant, clone.Tenant));
+
+            // values are equal
+            Assert.Equal(original.Subscription.Id, clone.Subscription.Id);
+            Assert.Equal(original.Account.Id, clone.Account.Id);
+            Assert.Equal(original.Environment.Name, clone.Environment.Name);
+            Assert.Equal(original.Tenant.Id, clone.Tenant.Id);
+
+            // custom property
+            Assert.Equal(SubHomeTenant, clone.Subscription.GetHomeTenant());
+            Assert.Equal(PropertyValue, clone.GetProperty(PropertyKey));
+        }
+
+        [Fact]
+        public void TestDeepCopyNull()
+        {
+            IAzureContext original = null;
+            Assert.Null(original.DeepCopy());
+        }
+    }
+}

--- a/src/Authentication.Abstractions.Test/ContextUnitTests.cs
+++ b/src/Authentication.Abstractions.Test/ContextUnitTests.cs
@@ -53,11 +53,11 @@ namespace Authentication.Abstractions.Test
             IAzureContext clone = original.DeepCopy();
 
             // references are not equal
-            Assert.False(ReferenceEquals(original, clone));
-            Assert.False(ReferenceEquals(original.Subscription, clone.Subscription));
-            Assert.False(ReferenceEquals(original.Account, clone.Account));
-            Assert.False(ReferenceEquals(original.Environment, clone.Environment));
-            Assert.False(ReferenceEquals(original.Tenant, clone.Tenant));
+            Assert.NotSame(original, clone);
+            Assert.NotSame(original.Subscription, clone.Subscription);
+            Assert.NotSame(original.Account, clone.Account);
+            Assert.NotSame(original.Environment, clone.Environment);
+            Assert.NotSame(original.Tenant, clone.Tenant);
 
             // values are equal
             Assert.Equal(original.Subscription.Id, clone.Subscription.Id);

--- a/src/Authentication.Abstractions/Extensions/AzureContextExtensions.cs
+++ b/src/Authentication.Abstractions/Extensions/AzureContextExtensions.cs
@@ -148,5 +148,27 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 context.UpdateProperties(other);
             }
         }
+
+        /// <summary>
+        /// Deep copy a context.
+        /// </summary>
+        /// <returns>The copy.</returns>
+        public static IAzureContext DeepCopy(this IAzureContext context)
+        {
+            if (context == null)
+            {
+                return null;
+            }
+            var deepCopy = new AzureContext()
+            {
+                VersionProfile = context.VersionProfile
+            };
+            deepCopy.Account.CopyFrom(context.Account);
+            deepCopy.Tenant.CopyFrom(context.Tenant);
+            deepCopy.Subscription.CopyFrom(context.Subscription);
+            deepCopy.Environment.CopyFrom(context.Environment);
+            deepCopy.CopyPropertiesFrom(context);
+            return deepCopy;
+        }
     }
 }

--- a/src/Authentication.Abstractions/Extensions/AzureContextExtensions.cs
+++ b/src/Authentication.Abstractions/Extensions/AzureContextExtensions.cs
@@ -161,6 +161,10 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
             }
             var deepCopy = new AzureContext()
             {
+                Account = new AzureAccount(),
+                Tenant = new AzureTenant(),
+                Subscription = new AzureSubscription(),
+                Environment = new AzureEnvironment(),
                 VersionProfile = context.VersionProfile
             };
             deepCopy.Account.CopyFrom(context.Account);

--- a/src/Authentication.Abstractions/Interfaces/IAzureContextContainer.cs
+++ b/src/Authentication.Abstractions/Interfaces/IAzureContextContainer.cs
@@ -51,9 +51,10 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         void Clear();
 
         /// <summary>
-        /// Shallow copy all properties.
+        /// Copy the context container for overriding default context.
+        /// See <see cref="SupportsSubscriptionIdAttribute"/>
         /// </summary>
         /// <returns>The copy.</returns>
-        IAzureContextContainer ShallowCopy();
+        IAzureContextContainer CopyForContextOverriding();
     }
 }

--- a/src/Authentication.Abstractions/Interfaces/IAzureContextContainer.cs
+++ b/src/Authentication.Abstractions/Interfaces/IAzureContextContainer.cs
@@ -49,5 +49,11 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// Remove all contexts from the container
         /// </summary>
         void Clear();
+
+        /// <summary>
+        /// Shallow copy all properties.
+        /// </summary>
+        /// <returns>The copy.</returns>
+        IAzureContextContainer ShallowCopy();
     }
 }

--- a/src/Common/Attributes/SupportsSubscriptionId.cs
+++ b/src/Common/Attributes/SupportsSubscriptionId.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Management.Automation;
+
+namespace Microsoft.WindowsAzure.Commands.Common.Attributes
+{
+    /// <summary>
+    /// Indicates a cmdlet supports overriding subscription ID via `-SubscriptionId` parameter.
+    /// </summary>
+    public class SupportsSubscriptionIdAttribute : Attribute
+    {
+    }
+}

--- a/src/Common/Attributes/SupportsSubscriptionId.cs
+++ b/src/Common/Attributes/SupportsSubscriptionId.cs
@@ -1,5 +1,18 @@
-﻿using System;
-using System.Management.Automation;
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using System;
 
 namespace Microsoft.WindowsAzure.Commands.Common.Attributes
 {

--- a/src/ResourceManager.Test/AzureRMCmdletUnitTests.cs
+++ b/src/ResourceManager.Test/AzureRMCmdletUnitTests.cs
@@ -1,0 +1,83 @@
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.ResourceManager.Common;
+using Microsoft.WindowsAzure.Commands.Common.Attributes;
+using System;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using Xunit;
+
+namespace Microsoft.Azure.Commands.ResourceManager.Test
+{
+    public class AzureRMCmdletUnitTests
+    {
+        [Fact]
+        public void HasAttributeHasSubId()
+        {
+            var positive = new PositiveCmdlet();
+            var dynamicParameters = positive.GetDynamicParameters() as RuntimeDefinedParameterDictionary;
+            Assert.NotNull(dynamicParameters);
+            Assert.Single(dynamicParameters);
+            Assert.NotNull(dynamicParameters["SubscriptionId"]);
+        }
+
+        [Fact]
+        public void NoAttributeNoSubId()
+        {
+            var negative = new NegativeCmdlet();
+            var dynamicParameters = negative.GetDynamicParameters() as RuntimeDefinedParameterDictionary;
+            Assert.Empty(dynamicParameters);
+        }
+
+        [Fact]
+        public void DoubleDynamicParameters()
+        {
+            // when child cmdlet also has dynamic parameter
+            // it should combine with base class
+            var positiveWithOwnParam = new PositiveCmdletWithOwnDynamicParam();
+            var dynamicParameters = positiveWithOwnParam.GetDynamicParameters() as RuntimeDefinedParameterDictionary;
+            Assert.NotNull(dynamicParameters);
+            Assert.Collection(dynamicParameters,
+                pair => { Assert.Equal("SubscriptionId", pair.Key); },
+                pair => { Assert.Equal("DP", pair.Key); }
+            );
+        }
+
+        [SupportsSubscriptionId]
+        class PositiveCmdlet : AzureRMCmdlet
+        {
+        }
+
+        class NegativeCmdlet : AzureRMCmdlet { }
+
+        [SupportsSubscriptionId]
+        class PositiveCmdletWithOwnDynamicParam : AzureRMCmdlet, IDynamicParameters
+        {
+            public new object GetDynamicParameters()
+            {
+                var parameters = base.GetDynamicParameters() as RuntimeDefinedParameterDictionary;
+                parameters.Add("DP", new RuntimeDefinedParameter(
+                    "DP",
+                    typeof(string),
+                    new Collection<Attribute>()
+                    {
+                        new ParameterAttribute { }
+                    }
+                ));
+                return parameters;
+            }
+        }
+    }
+}

--- a/src/ResourceManager/Properties/Resources.Designer.cs
+++ b/src/ResourceManager/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -64,8 +64,9 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common.Properties {
         ///   Looks up a localized string similar to Azure PowerShell collects usage data in order to improve your experience.
         ///The data is anonymous and does not include commandline argument values.
         ///The data is collected by Microsoft.
-        ///Use the Disable-AzDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the Az.Accounts module. To disable data collection: PS &gt; Disable-AzDataCollection.
-        ///Use the Enable-AzDataCollection cmdlet to turn the feature On. The cmdlet can be found in the Az.Accounts module. To enable  [rest of string was truncated]&quot;;.
+        ///
+        ///Use the Disable-AzDataCollection cmdlet to turn the feature Off. The cmdlet can be found in the Az.Accounts. To disable data collection: PS &gt; Disable-AzDataCollection.
+        ///Use the Enable-AzDataCollection cmdlet to turn the feature On. The cmdlet can be found in the Az.Accounts module. To enable data collection: PS &gt; Enable-AzD [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ARMDataCollectionMessage {
             get {
@@ -88,6 +89,15 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common.Properties {
         public static string ContextCannotBeNull {
             get {
                 return ResourceManager.GetString("ContextCannotBeNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not found subscription &apos;{0}&apos; in context. Please run &apos;Connect-AzAccount&apos; with correct user..
+        /// </summary>
+        public static string CustomSubscriptionNotFound {
+            get {
+                return ResourceManager.GetString("CustomSubscriptionNotFound", resourceCulture);
             }
         }
         
@@ -300,6 +310,17 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common.Properties {
         public static string RunConnectAccount {
             get {
                 return ResourceManager.GetString("RunConnectAccount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The ID of the subscription.
+        ///By default, cmdlets are executed in the subscription that is set in the current context. If the user specifies another subscription, the current cmdlet is executed in the subscription specified by the user.
+        ///Overriding subscriptions only take effect during the lifecycle of the current cmdlet. It does not change the subscription in the context, and does not affect subsequent cmdlets..
+        /// </summary>
+        public static string SubscriptionIdHelpMessage {
+            get {
+                return ResourceManager.GetString("SubscriptionIdHelpMessage", resourceCulture);
             }
         }
         

--- a/src/ResourceManager/Properties/Resources.resx
+++ b/src/ResourceManager/Properties/Resources.resx
@@ -222,4 +222,12 @@ Use the Enable-AzureDataCollection cmdlet to turn the feature On. The cmdlet can
   <data name="RunConnectAccount" xml:space="preserve">
     <value>Run Connect-AzAccount to login.</value>
   </data>
+  <data name="SubscriptionIdHelpMessage" xml:space="preserve">
+    <value>The ID of the subscription.
+By default, cmdlets are executed in the subscription that is set in the current context. If the user specifies another subscription, the current cmdlet is executed in the subscription specified by the user.
+Overriding subscriptions only take effect during the lifecycle of the current cmdlet. It does not change the subscription in the context, and does not affect subsequent cmdlets.</value>
+  </data>
+  <data name="CustomSubscriptionNotFound" xml:space="preserve">
+    <value>Could not found subscription '{0}' in context. Please run 'Connect-AzAccount' with correct user.</value>
+  </data>
 </root>

--- a/src/ResourceManager/ResourceManager.csproj
+++ b/src/ResourceManager/ResourceManager.csproj
@@ -44,7 +44,7 @@
 
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
-      <DesignTime>true</DesignTime>
+      <DesignTime>True</DesignTime>
       <AutoGen>true</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
@@ -52,7 +52,7 @@
 
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Problem

autorest-based modules support `-Subscription` parameter to operate on non-default subscription, but there's no universal way to enable it for sdk-based ones.

### Solution

A `SupportsSubscriptionId` attribute is introduced. When applied to a cmdlet (or a cmdlet base class), the cmdlet(s) will have a `-SubscriptionId` parameter, implemented by `IDynamicParameter`. And during its lifecycle, the default profile and context will be cloned, the subscription will be replaced by what user specifies. Therefore when creeating SDK client or sending request, the input subscription ID will be used.