### PR TITLE
Undo adding new API to IAzureContextContainer

### DIFF
--- a/src/Authentication.Abstractions/Interfaces/IAzureContextContainer.cs
+++ b/src/Authentication.Abstractions/Interfaces/IAzureContextContainer.cs
@@ -49,12 +49,5 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// Remove all contexts from the container
         /// </summary>
         void Clear();
-
-        /// <summary>
-        /// Copy the context container for overriding default context.
-        /// See <see cref="SupportsSubscriptionIdAttribute"/>
-        /// </summary>
-        /// <returns>The copy.</returns>
-        IAzureContextContainer CopyForContextOverriding();
     }
 }

--- a/src/Common/Utilities/ISharedUtilities.cs
+++ b/src/Common/Utilities/ISharedUtilities.cs
@@ -1,0 +1,33 @@
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.Common.Authentication.Abstractions.Core;
+
+namespace Microsoft.WindowsAzure.Commands.Common.Utilities
+{
+    /// <summary>
+    /// Contains helper methods shared between common lib and Az.Accounts.
+    /// An instance of a class that implements this interface should be registered to the session.
+    /// </summary>
+    public interface ISharedUtilities
+    {
+        /// <summary>
+        /// Copy the context container for overriding default context.
+        /// See <see cref="Attributes.SupportsSubscriptionIdAttribute"/>.
+        /// </summary>
+        /// <param name="contextContainer">The original.</param>
+        /// <returns>The copy.</returns>
+        IAzureContextContainer CopyForContextOverriding(IAzureContextContainer contextContainer);
+    }
+}

--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -25,6 +25,7 @@ using Microsoft.Azure.Management.Internal.Resources.Utilities.Models;
 using Microsoft.Rest;
 using Microsoft.WindowsAzure.Commands.Common;
 using Microsoft.WindowsAzure.Commands.Common.Attributes;
+using Microsoft.WindowsAzure.Commands.Common.Utilities;
 using Microsoft.WindowsAzure.Commands.Utilities.Common;
 using System;
 using System.Collections.Generic;
@@ -111,7 +112,14 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
                 if (matchingSub != null)
                 {
                     // going to modify default context, so only shallow copying other stuff
-                    profile = GetDefaultProfile().CopyForContextOverriding();
+                    if (AzureSession.Instance.TryGetComponent<ISharedUtilities>(nameof(ISharedUtilities), out var sharedUtilities))
+                    {
+                        profile = sharedUtilities.CopyForContextOverriding(GetDefaultProfile());
+                    }
+                    else
+                    {
+                        throw new AzPSException(Resources.ProfileNotInitialized, Commands.Common.ErrorKind.InternalError);
+                    }
                     profile.DefaultContext = profile.DefaultContext.DeepCopy();
                     profile.DefaultContext.Subscription.CopyFrom(matchingSub);
                     profile.DefaultContext.Tenant.Id = matchingSub.GetTenant();


### PR DESCRIPTION
Adding APIs to well-known types (`IAzureContextContainer` in this case) is risky as:

- It is a binary breaking change - what if someone implements the interface in their own code
- It is harder not to introduce breaking change the bigger the interface grows.

So, we came up with a pattern to avoid touching `IAzureContextContainer`, using `ComponentRegistery`.
Related powershell PR: https://github.com/Azure/azure-powershell/pull/15743