### PR TITLE
Publish symbol packages as "*.snupkg"

### DIFF
--- a/.azure-pipelines/Azure-PowerShell-Common-Publish.yml
+++ b/.azure-pipelines/Azure-PowerShell-Common-Publish.yml
@@ -91,8 +91,9 @@ steps:
   condition: and(succeeded(), ne(variables['publish'], 'false'))
   inputs:
     command: push
-    packagesToPush: 'artifacts/Package/Release/Microsoft.Azure.PowerShell.*.nupkg'
+    packagesToPush: 'artifacts/Package/Release/Microsoft.Azure.PowerShell.*.[s]nupkg'
     publishVstsFeed: public/azure-powershell
+    allowPackageConflicts: true
 
 - powershell: |
    dotnet msbuild build\publish.proj /p:Configuration=Release /p:ReleaseVersion=$env:VERSION /p:CommitId=$env:Build_SourceVersion /p:GitHubAccessToken=$(Github-azuresdkci-personalaccesstoken)  /NoLogo

--- a/src/Dependencies.targets
+++ b/src/Dependencies.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup Condition="'$(OmitJsonPackage)' != 'true'">
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />


### PR DESCRIPTION
> The legacy format .symbols.nupkg is still supported but only for compatibility reasons like native packages (see Legacy Symbol Packages). NuGet.org's symbol server only accepts the new symbol package format - .snupkg.

-- https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#creating-a-symbol-package

This PR changes the output symbol package type to `.snupkg` and configures the pipeline publish symbol packages as well as library packages.