### PR TITLE
Update build image to windows-2019

### DIFF
--- a/.azure-pipelines/Azure-PowerShell-Common-Publish.yml
+++ b/.azure-pipelines/Azure-PowerShell-Common-Publish.yml
@@ -7,7 +7,7 @@ trigger:
 - main
 
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-2019'
 
 variables:
 - group: GitHub Release Variables


### PR DESCRIPTION
Update the vm image of pipeline [azure-powershell-common sign & publish](https://dev.azure.com/azure-sdk/internal/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=2436&nonce=HmQHyxzMgBiMb22MoZJGOg%3D%3D) to windows-2019

Issue: https://github.com/Azure/azure-powershell/issues/16275

- [x] Sign build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1194976&view=results