### PR TITLE
Update common lib for telemetry improvement

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -378,14 +378,14 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                     _qosEvent.SurveyPrompted = true;
                 }
             }
-            if (MetricHelper.TelemetryId == "")
+            if (MetricHelper.IsCalledByUser())
             {
                 // Send telemetry when cmdlet is directly called by user
                 LogQosEvent();
             }
             else {
-                // When cmdlet is called with another cmdlet, we will not add a new telemetry, but add the cmdlet name to InternalCalledCmdlets
-                MetricHelper.InternalCalledCmdlets += (MetricHelper.InternalCalledCmdlets == "" ? "" : ",") + this.MyInvocation?.MyCommand?.Name;
+                // When cmdlet is called within another cmdlet, we will not add a new telemetry, but add the cmdlet name to InternalCalledCmdlets
+                MetricHelper.AppendInternalCalledCmdlet(this.MyInvocation?.MyCommand?.Name);
             }
             LogCmdletEndInvocationInfo();
             TearDownDebuggingTraces();

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -378,13 +378,22 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                     _qosEvent.SurveyPrompted = true;
                 }
             }
-            LogQosEvent();
+            if (MetricHelper.TelemetryId == "")
+            {
+                // Send telemetry when cmdlet is directly called by user
+                LogQosEvent();
+            }
+            else {
+                // When cmdlet is called with another cmdlet, we will not add a new telemetry, but add the cmdlet name to InternalCalledCmdlets
+                MetricHelper.InternalCalledCmdlets += (MetricHelper.InternalCalledCmdlets == "" ? "" : ",") + this.MyInvocation?.MyCommand?.Name;
+            }
             LogCmdletEndInvocationInfo();
             TearDownDebuggingTraces();
             TearDownHttpClientPipeline();
             _previousEndTime = DateTimeOffset.Now;
             base.EndProcessing();
         }
+
 
         protected string CurrentPath()
         {
@@ -619,7 +628,8 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             _qosEvent = new AzurePSQoSEvent()
             {
                 ClientRequestId = this._clientRequestId,
-                SessionId = _sessionId,
+                // Use SessionId from MetricHelper so that generated cmdlet and handcrafted cmdlet could share the same Id
+                SessionId = MetricHelper.SessionId,
                 IsSuccess = true,
                 ParameterSetName = this.ParameterSetName,
                 PreviousEndTime = _previousEndTime

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -40,6 +40,26 @@ namespace Microsoft.WindowsAzure.Commands.Common
         private const string DefaultPSVersion = "3.0.0.0";
         private const string EventName = "cmdletInvocation";
 
+        public static string SessionId { get; } = System.Guid.NewGuid().ToString();
+
+        [ThreadStatic]
+        private static string _telemetryId = "";
+        [ThreadStatic]
+        private static string _internalCalledCmdlets = "";
+
+        public static string TelemetryId { get=> _telemetryId; set { _telemetryId = value; } }
+
+        public static string InternalCalledCmdlets { get => _internalCalledCmdlets; set { _internalCalledCmdlets = value; } }
+
+        /// <summary>
+        /// Clear telemetry context.
+        /// </summary>
+        public static void ClearTelemetryContext()
+        {
+            _telemetryId = "";
+            _internalCalledCmdlets = "";
+        }
+
         /// <summary>
         /// The collection of telemetry clients.
         /// </summary>
@@ -251,6 +271,10 @@ namespace Microsoft.WindowsAzure.Commands.Common
 
         private void PopulatePropertiesFromQos(AzurePSQoSEvent qos, IDictionary<string, string> eventProperties, bool populateException = false)
         {
+#if DEBUG
+            string telemetryFilePath = System.IO.Path.GetTempPath() + "azure-powershell-telemetry.txt";
+            System.IO.File.AppendAllText(telemetryFilePath, qos.ToString() + "\n");
+#endif
             if (qos == null)
             {
                 return;
@@ -278,7 +302,8 @@ namespace Microsoft.WindowsAzure.Commands.Common
             eventProperties.Add("start-time", qos.StartTime.ToUniversalTime().ToString("o"));
             eventProperties.Add("end-time", qos.EndTime.ToUniversalTime().ToString("o"));
             eventProperties.Add("duration", qos.Duration.ToString("c"));
-            if(!string.IsNullOrWhiteSpace(SharedVariable.PredictorCorrelationId))
+            eventProperties.Add("InternalCalledCmdlets", MetricHelper.InternalCalledCmdlets);
+            if (!string.IsNullOrWhiteSpace(SharedVariable.PredictorCorrelationId))
             {
                 eventProperties.Add("predictor-correlation-id", SharedVariable.PredictorCorrelationId);
                 SharedVariable.PredictorCorrelationId = null;
@@ -580,7 +605,7 @@ public class AzurePSQoSEvent
 
     public override string ToString()
     {
-        string ret = $"AzureQoSEvent: Module: {ModuleName}:{ModuleVersion}; CommandName: {CommandName}; PSVersion: {PSVersion}";
+        string ret = $"AzureQoSEvent: Module: {ModuleName}:{ModuleVersion}; Session:{SessionId}; CommandName: {CommandName}; PSVersion: {PSVersion}; InternalCalledCmdlets: {Microsoft.WindowsAzure.Commands.Common.MetricHelper.InternalCalledCmdlets}";
         ret += $"; IsSuccess: {IsSuccess}; Duration: {Duration}";
 
         if (Exception != null)

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -271,10 +271,6 @@ namespace Microsoft.WindowsAzure.Commands.Common
 
         private void PopulatePropertiesFromQos(AzurePSQoSEvent qos, IDictionary<string, string> eventProperties, bool populateException = false)
         {
-#if DEBUG
-            string telemetryFilePath = System.IO.Path.GetTempPath() + "azure-powershell-telemetry.txt";
-            System.IO.File.AppendAllText(telemetryFilePath, qos.ToString() + "\n");
-#endif
             if (qos == null)
             {
                 return;
@@ -605,7 +601,12 @@ public class AzurePSQoSEvent
 
     public override string ToString()
     {
+#if DEBUG
         string ret = $"AzureQoSEvent: Module: {ModuleName}:{ModuleVersion}; Session:{SessionId}; CommandName: {CommandName}; PSVersion: {PSVersion}; InternalCalledCmdlets: {Microsoft.WindowsAzure.Commands.Common.MetricHelper.InternalCalledCmdlets}";
+#else
+        string ret = $"AzureQoSEvent: Module: {ModuleName}:{ModuleVersion}; CommandName: {CommandName}; PSVersion: {PSVersion}";
+#endif 
+        
         ret += $"; IsSuccess: {IsSuccess}; Duration: {Duration}";
 
         if (Exception != null)

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -42,6 +42,9 @@ namespace Microsoft.WindowsAzure.Commands.Common
 
         public static string SessionId { get; } = System.Guid.NewGuid().ToString();
 
+        /// <summary>
+        /// Set _telemetryId and _internalCalledCmdlets as thread local since we need an instance of them per thread.
+        /// </summary>
         [ThreadStatic]
         private static string _telemetryId = "";
         [ThreadStatic]
@@ -50,6 +53,10 @@ namespace Microsoft.WindowsAzure.Commands.Common
         public static string TelemetryId { get=> _telemetryId; set { _telemetryId = value; } }
 
         public static string InternalCalledCmdlets { get => _internalCalledCmdlets; set { _internalCalledCmdlets = value; } }
+
+        public static bool IsCalledByUser() { return _telemetryId == "" ? true : false; }
+
+        public static void AppendInternalCalledCmdlet(string cmldetName) { _internalCalledCmdlets += (_internalCalledCmdlets == "" ? "" : ",") + cmldetName; }
 
         /// <summary>
         /// Clear telemetry context.


### PR DESCRIPTION
- Add property SessionId, which is used to identify a PowerShell Process
- Add thread level property TelemetryId, which is used to identify a telemetry
- Add thread level property InternalCalledCmdlets, which keeps the internal called cmdlets