### PR TITLE
Write log with timestamps

### DIFF
--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -641,17 +641,17 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
 
         private void WriteDebugSender(object sender, StreamEventArgs args)
         {
-            WriteDebug(args.Message);
+            WriteDebugWithTimestamp(args.Message);
         }
 
         private void WriteVerboseSender(object sender, StreamEventArgs args)
         {
-            WriteVerbose(args.Message);
+            WriteVerboseWithTimestamp(args.Message);
         }
 
         private void WriteWarningSender(object sender, StreamEventArgs args)
         {
-            WriteWarning(args.Message);
+            WriteWarningWithTimestamp(args.Message);
         }
 
         private void EnqueueDebugSender(object sender, StreamEventArgs args)


### PR DESCRIPTION
Provide a little extra information in logs (debug, warning and verbose).

Before vs. After. Note the fifth line.
![image](https://user-images.githubusercontent.com/11371776/157411796-01aa5136-4397-4cb3-950f-c375a0887959.png)
![image](https://user-images.githubusercontent.com/11371776/157411820-8b95b0a1-2f61-4994-992f-cc0127031f8d.png)
