### PR TITLE
Upgrade the version of Microsoft.Rest.ClientRuntime.Azure

### DIFF
--- a/src/Dependencies.targets
+++ b/src/Dependencies.targets
@@ -9,7 +9,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
   <ItemGroup>
-     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
+     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
  </ItemGroup>
   <ItemGroup Condition="'$(IncludeHyak)' == 'true'">
     <PackageReference Include="Microsoft.Azure.Common" Version="2.2.1" />


### PR DESCRIPTION
Just upgrade the version of Microsoft.Rest.ClientRuntime.Azure. We don't need to release a new version only for this change.