### PR TITLE
Fixed a telemtry related issue in multi-thread

### DIFF
--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -46,9 +46,9 @@ namespace Microsoft.WindowsAzure.Commands.Common
         /// Set _telemetryId and _internalCalledCmdlets as thread local since we need an instance of them per thread.
         /// </summary>
         [ThreadStatic]
-        private static string _telemetryId = "";
+        private static string _telemetryId;
         [ThreadStatic]
-        private static string _internalCalledCmdlets = "";
+        private static string _internalCalledCmdlets;
 
         public static string TelemetryId { get => _telemetryId ?? ""; set { _telemetryId = value; } }
 

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -54,7 +54,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
 
         public static string InternalCalledCmdlets { get => _internalCalledCmdlets ?? ""; set { _internalCalledCmdlets = value; } }
 
-        public static bool IsCalledByUser() { return string.IsNullOrEmpty(_telemetryId) ? true : false; }
+        public static bool IsCalledByUser() { return string.IsNullOrEmpty(_telemetryId); }
 
         public static void AppendInternalCalledCmdlet(string cmldetName) { _internalCalledCmdlets += (string.IsNullOrEmpty(_internalCalledCmdlets) ? "" : ",") + cmldetName; }
 

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -50,13 +50,13 @@ namespace Microsoft.WindowsAzure.Commands.Common
         [ThreadStatic]
         private static string _internalCalledCmdlets = "";
 
-        public static string TelemetryId { get=> _telemetryId; set { _telemetryId = value; } }
+        public static string TelemetryId { get => _telemetryId ?? ""; set { _telemetryId = value; } }
 
-        public static string InternalCalledCmdlets { get => _internalCalledCmdlets; set { _internalCalledCmdlets = value; } }
+        public static string InternalCalledCmdlets { get => _internalCalledCmdlets ?? ""; set { _internalCalledCmdlets = value; } }
 
-        public static bool IsCalledByUser() { return _telemetryId == "" ? true : false; }
+        public static bool IsCalledByUser() { return string.IsNullOrEmpty(_telemetryId) ? true : false; }
 
-        public static void AppendInternalCalledCmdlet(string cmldetName) { _internalCalledCmdlets += (_internalCalledCmdlets == "" ? "" : ",") + cmldetName; }
+        public static void AppendInternalCalledCmdlet(string cmldetName) { _internalCalledCmdlets += (string.IsNullOrEmpty(_internalCalledCmdlets) ? "" : ",") + cmldetName; }
 
         /// <summary>
         /// Clear telemetry context.


### PR DESCRIPTION
The root cause of the issue is as listed in [here](https://docs.microsoft.com/en-us/dotnet/api/system.threadstaticattribute?redirectedfrom=MSDN&view=net-6.0). 
`Initialization occurs only once, when the class constructor executes, and therefore affects only one thread.`
