### PR TITLE
Changed default cancellation token

### DIFF
--- a/src/Common/Utilities/GeneralUtilities.cs
+++ b/src/Common/Utilities/GeneralUtilities.cs
@@ -625,7 +625,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             if (request.Content != null)
             {
                 var output = new MemoryStream();
-                request.Content.WriteTo(output, default);
+                request.Content.WriteTo(output, System.Threading.CancellationToken.None);
                 output.Seek(0, SeekOrigin.Begin);
                 body = TryFormatJson(new StreamReader(output).ReadToEnd());
             }


### PR DESCRIPTION
Changed default cancellation token from "default" to "CancellationToken.None" as C# 7.0 does not support it