### PR TITLE
Fixed issue when EnableTestCoverage was not registered

### DIFF
--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -186,9 +186,9 @@ namespace Microsoft.WindowsAzure.Commands.Common
                 return;
 
             if (!string.IsNullOrEmpty(qos.SourceScript)
+                && AzureSession.Instance.TryGetComponent<ITestCoverage>(nameof(ITestCoverage), out var testCoverage)
                 && AzureSession.Instance.TryGetComponent<IConfigManager>(nameof(IConfigManager), out var configManager)
-                && configManager.GetConfigValue<bool>(ConfigKeysForCommon.EnableTestCoverage)
-                && AzureSession.Instance.TryGetComponent<ITestCoverage>(nameof(ITestCoverage), out var testCoverage))
+                && configManager.GetConfigValue<bool>(ConfigKeysForCommon.EnableTestCoverage))
             {
                 testCoverage.LogRawData(qos);
             }


### PR DESCRIPTION
Fixed the issue in the Release build where EnableTestCoverage flag is not registered. The release build also does not have ITestCoverage component registered. Move this condition ahead of EnableTestCoverage flag to short-circuit the if logic.