### PR TITLE
Allow doing stuff after config is applied

### DIFF
--- a/src/Authentication.Abstractions/Models/ConfigDefinition.cs
+++ b/src/Authentication.Abstractions/Models/ConfigDefinition.cs
@@ -89,10 +89,16 @@ namespace Microsoft.Azure.PowerShell.Common.Config
         public virtual void Validate(object value) { }
 
         /// <summary>
-        /// Override in derived classes to perform side effects of applying the config value.
+        /// Override in derived classes to perform side effects *before* applying the config value.
         /// If a exception is thrown, the config will not be updated.
         /// </summary>
         /// <param name="value">Value of the config to apply.</param>
         public virtual void Apply(object value) { }
+
+        /// <summary>
+        /// Override in derived classes to perform side effects *after* applying the config value.
+        /// </summary>
+        /// <param name="value">Updated value.</param>
+        public virtual void AfterApply(object value) { }
     }
 }


### PR DESCRIPTION
Extends `ConfigDefinition` type to allow configs to define actions *after* a new value is applied. (Adding a virtual method to an abstract class is not a binary breaking change.)
This is part of the work to support configuring login with WAM, as the `AuthenticatorBuilder` needs to be reset *after* the WAM config is updated.
