### PR TITLE
Use $PSVersionTable.PSVersion for PowerShell Version

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -1065,7 +1065,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
         {
             try
             {
-                var outputs = this.ExecuteScript<PSObject>("$Host.Runspace.Version");
+                var outputs = this.ExecuteScript<PSObject>("$PSVersionTable.PSVersion");
                 foreach (PSObject obj in outputs)
                 {
                     string psVersion = obj.ToString();


### PR DESCRIPTION
Currently, we use $Host.runspace.version for PowerShell version. It is the PowerShell engine version, and should be same as the $psversiontable.psversion, but runspace will be null in some cases for example when developers directly use PowerShell SDK as below.

```
# $sp = [runspaceFactory]::CreateRunspace() # Create an space with default host
# $ps = [powershell]::create() # create an powershell object
# $ps.Runspace = $sp
# $sp.Open()
# $ps.AddScript{Get-host}.Invoke() # runspace is null for such an case
```