### PR TITLE
Support ArmMetadata with API version 2022-09-01

### DIFF
--- a/src/Authentication.Abstractions.Test/AzureEnvironmentTests.cs
+++ b/src/Authentication.Abstractions.Test/AzureEnvironmentTests.cs
@@ -53,6 +53,29 @@ namespace Authentication.Abstractions.Test
         }
 
         [Fact]
+        public void TestArmCloudMetadata20220901Init()
+        {
+            Environment.SetEnvironmentVariable(ArmMetadataEnvVariable, @"TestData\ArmResponse2022-09-01.json");
+            var armEnvironments = AzureEnvironment.InitializeBuiltInEnvironments(null, httpOperations: TestOperationsFactory.Create().GetHttpOperations());
+
+            // Check all discovered environments are loaded.
+            Assert.Equal(3, armEnvironments.Count);
+            foreach (var env in armEnvironments.Values)
+            {
+                if (env.Name == "AzureCloud")
+                {
+                    Assert.Equal(AzureEnvironment.TypeDiscovered, env.Type);
+                }
+                else
+                {
+                    Assert.Equal(AzureEnvironment.TypeBuiltIn, env.Type);
+                }
+                Assert.EndsWith("/", env.ServiceManagementUrl);
+                Assert.StartsWith(".", env.SqlDatabaseDnsSuffix);
+            }
+        }
+
+        [Fact]
         public void TestArmResponseNoAzureCloud()
         {
             Environment.SetEnvironmentVariable(ArmMetadataEnvVariable, @"TestData\ArmResponseNoAzureCloud.json");

--- a/src/Authentication.Abstractions.Test/TestData/ArmResponse2022-09-01.json
+++ b/src/Authentication.Abstractions.Test/TestData/ArmResponse2022-09-01.json
@@ -1,0 +1,41 @@
+{
+  "portal": "https://portal.azure.com",
+  "authentication": {
+    "loginEndpoint": "https://login.microsoftonline.com",
+    "audiences": [ "https://management.core.windows.net/", "https://management.azure.com/" ],
+    "tenant": "common",
+    "identityProvider": "AAD"
+  },
+  "media": "https://rest.media.azure.net",
+  "graphAudience": "https://graph.windows.net/",
+  "graph": "https://graph.windows.net/",
+  "name": "AzureCloud",
+  "suffixes": {
+    "azureDataLakeStoreFileSystem": "azuredatalakestore.net",
+    "acrLoginServer": "azurecr.io",
+    "sqlServerHostname": "database.windows.net",
+    "azureDataLakeAnalyticsCatalogAndJob": "azuredatalakeanalytics.net",
+    "keyVaultDns": "vault.azure.net",
+    "storage": "core.windows.net",
+    "azureFrontDoorEndpointSuffix": "azurefd.net",
+    "storageSyncEndpointSuffix": "afs.azure.net",
+    "mhsmDns": "managedhsm.azure.net",
+    "mysqlServerEndpoint": "mysql.database.azure.com",
+    "postgresqlServerEndpoint": "postgres.database.azure.com",
+    "mariadbServerEndpoint": "mariadb.database.azure.com",
+    "synapseAnalytics": "dev.azuresynapse.net",
+    "attestationEndpoint": "attest.azure.net"
+  },
+  "batch": "https://batch.core.windows.net/",
+  "resourceManager": "https://management.azure.com/",
+  "vmImageAliasDoc": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
+  "activeDirectoryDataLake": "https://datalake.azure.net/",
+  "sqlManagement": "https://management.core.windows.net:8443/",
+  "microsoftGraphResourceId": "https://graph.microsoft.com/",
+  "appInsightsResourceId": "https://api.applicationinsights.io",
+  "appInsightsTelemetryChannelResourceId": "https://dc.applicationinsights.azure.com/v2/track",
+  "attestationResourceId": "https://attest.azure.net",
+  "synapseAnalyticsResourceId": "https://dev.azuresynapse.net",
+  "logAnalyticsResourceId": "https://api.loganalytics.io",
+  "ossrDbmsResourceId": "https://ossrdbms-aad.database.windows.net"
+}

--- a/src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs
@@ -12,15 +12,7 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
-using Microsoft.Azure.Commands.Common.Authentication.Abstractions.Interfaces;
-using Microsoft.Azure.Commands.Common.Authentication.Abstractions.Models;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
 {
@@ -35,7 +27,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// </summary>
         private static AzureEnvironment GetBuiltInAzureCloud()
         {
-            var azureEnv = new AzureEnvironment
+            return new AzureEnvironment
             {
                 Name = EnvironmentName.AzureCloud,
                 Type = TypeBuiltIn,
@@ -70,7 +62,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                     { ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.AzureSynapseAnalyticsEndpointResourceId }
                 }
             };
-            return azureEnv;
         }
 
         /// <summary>
@@ -78,7 +69,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// </summary>
         private static AzureEnvironment GetBuiltInChinaAzureCloud()
         {
-            var azureEnv = new AzureEnvironment
+            return new AzureEnvironment
             {
                 Name = EnvironmentName.AzureChinaCloud,
                 Type = TypeBuiltIn,
@@ -111,7 +102,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                     { ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.ChinaSynapseAnalyticsEndpointResourceId }
                 }
             };
-            return azureEnv;
         }
 
         /// <summary>
@@ -119,7 +109,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// </summary>
         private static AzureEnvironment GetBuiltInUSGovernmentCloud()
         {
-            var azureEnv = new AzureEnvironment
+            return new AzureEnvironment
             {
                 Name = EnvironmentName.AzureUSGovernment,
                 Type = TypeBuiltIn,
@@ -152,7 +142,6 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                     { ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.USGovernmentAnalysisServicesEndpointResourceId }
                 }
             };
-            return azureEnv;
         }
 
         /// <summary>

--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -70,8 +70,8 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                     }
                     catch (Exception e)
                     {
-                        warningLogger?.Invoke($"Cannot discover environments from Arm with Uri {armMetadataRequestUri}");
-                        warningLogger?.Invoke(e.StackTrace);
+                        warningLogger?.Invoke($"Cannot discover environments from ARM with URI {armMetadataRequestUri}. Falling back to built-in environments.");
+                        debugLogger?.Invoke(e.StackTrace);
                     }
                 }
             }

--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -29,11 +29,10 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
     /// location fo service-specific endpoints, and information for bootstrapping authentication
     /// </summary>
     [Serializable]
-    public class AzureEnvironment : IAzureEnvironment, IEquatable<AzureEnvironment>
+    public partial class AzureEnvironment : IAzureEnvironment, IEquatable<AzureEnvironment>
     {
         private const string ArmMetadataEnvVariable = "ARM_CLOUD_METADATA_URL";
 
-        private const string DefaultArmMetaDataEndpoint = "http://discover.azure.com/";
         private const string DisableArmMetaDataEndpoint = "DISABLED";
 
         internal static IDictionary<string, AzureEnvironment> InitializeBuiltInEnvironments(string armMetadataRequestUri, Action<string> debugLogger = null, Action<string> warningLogger = null, IHttpOperations httpOperations = null)
@@ -44,24 +43,20 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 if (string.IsNullOrEmpty(armMetadataRequestUri))
                 {
                     armMetadataRequestUri = Environment.GetEnvironmentVariable(ArmMetadataEnvVariable);
-                    if (string.IsNullOrEmpty(armMetadataRequestUri))
-                    {
-                        armMetadataRequestUri = DefaultArmMetaDataEndpoint;
-                    }
-                    else
+                    if (!string.IsNullOrEmpty(armMetadataRequestUri))
                     {
                         debugLogger?.Invoke($"Get {armMetadataRequestUri} from environment variable {ArmMetadataEnvVariable}");
                     }
                 }
                 if (DisableArmMetaDataEndpoint.Equals(armMetadataRequestUri?.Trim().ToUpper()))
                 {
-                    warningLogger?.Invoke($"Discover feature is disabled by environment variable {ArmMetadataEnvVariable}");
+                    warningLogger?.Invoke($"Discover feature is disabled.");
                     armMetadataRequestUri = null;
                 }
                 if (!string.IsNullOrEmpty(armMetadataRequestUri))
                 {
                     debugLogger?.Invoke($"Discover environments via {armMetadataRequestUri}");
-                    List<ArmMetadata> list = InitializeEnvironmentsFromArm(armMetadataRequestUri, httpOperations).ConfigureAwait(false).GetAwaiter().GetResult();
+                    var list = InitializeEnvironmentsFromArm(armMetadataRequestUri, httpOperations).ConfigureAwait(false).GetAwaiter().GetResult();
                     foreach (var metadata in list)
                     {
                         var env = MapArmToAzureEnvironment(metadata);
@@ -78,95 +73,18 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
             }
 
             debugLogger?.Invoke($"Load built-in environments");
-            var azureCloud = new AzureEnvironment
-            {
-                Name = EnvironmentName.AzureCloud,
-                Type = TypeBuiltIn,
-                PublishSettingsFileUrl = AzureEnvironmentConstants.AzurePublishSettingsFileUrl,
-                ServiceManagementUrl = AzureEnvironmentConstants.AzureServiceEndpoint,
-                ResourceManagerUrl = AzureEnvironmentConstants.AzureResourceManagerEndpoint,
-                ManagementPortalUrl = AzureEnvironmentConstants.AzureManagementPortalUrl,
-                ActiveDirectoryAuthority = AzureEnvironmentConstants.AzureActiveDirectoryEndpoint,
-                ActiveDirectoryServiceEndpointResourceId = AzureEnvironmentConstants.AzureServiceEndpoint,
-                StorageEndpointSuffix = AzureEnvironmentConstants.AzureStorageEndpointSuffix,
-                GalleryUrl = AzureEnvironmentConstants.GalleryEndpoint,
-                SqlDatabaseDnsSuffix = AzureEnvironmentConstants.AzureSqlDatabaseDnsSuffix,
-                GraphUrl = AzureEnvironmentConstants.AzureGraphEndpoint,
-                TrafficManagerDnsSuffix = AzureEnvironmentConstants.AzureTrafficManagerDnsSuffix,
-                AzureKeyVaultDnsSuffix = AzureEnvironmentConstants.AzureKeyVaultDnsSuffix,
-                AzureKeyVaultServiceEndpointResourceId = AzureEnvironmentConstants.AzureKeyVaultServiceEndpointResourceId,
-                AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = AzureEnvironmentConstants.AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix,
-                AzureDataLakeStoreFileSystemEndpointSuffix = AzureEnvironmentConstants.AzureDataLakeStoreFileSystemEndpointSuffix,
-                GraphEndpointResourceId = AzureEnvironmentConstants.AzureGraphEndpoint,
-                DataLakeEndpointResourceId = AzureEnvironmentConstants.AzureDataLakeServiceEndpointResourceId,
-                BatchEndpointResourceId = AzureEnvironmentConstants.BatchEndpointResourceId,
-                ContainerRegistryEndpointSuffix = AzureEnvironmentConstants.AzureContainerRegistryEndpointSuffix,
-                AdTenant = "Common"
-            };
-
-            var azureChina = new AzureEnvironment
-            {
-                Name = EnvironmentName.AzureChinaCloud,
-                Type = TypeBuiltIn,
-                PublishSettingsFileUrl = AzureEnvironmentConstants.ChinaPublishSettingsFileUrl,
-                ServiceManagementUrl = AzureEnvironmentConstants.ChinaServiceEndpoint,
-                ResourceManagerUrl = AzureEnvironmentConstants.ChinaResourceManagerEndpoint,
-                ManagementPortalUrl = AzureEnvironmentConstants.ChinaManagementPortalUrl,
-                ActiveDirectoryAuthority = AzureEnvironmentConstants.ChinaActiveDirectoryEndpoint,
-                ActiveDirectoryServiceEndpointResourceId = AzureEnvironmentConstants.ChinaServiceEndpoint,
-                StorageEndpointSuffix = AzureEnvironmentConstants.ChinaStorageEndpointSuffix,
-                GalleryUrl = AzureEnvironmentConstants.GalleryEndpoint,
-                SqlDatabaseDnsSuffix = AzureEnvironmentConstants.ChinaSqlDatabaseDnsSuffix,
-                GraphUrl = AzureEnvironmentConstants.ChinaGraphEndpoint,
-                TrafficManagerDnsSuffix = AzureEnvironmentConstants.ChinaTrafficManagerDnsSuffix,
-                AzureKeyVaultDnsSuffix = AzureEnvironmentConstants.ChinaKeyVaultDnsSuffix,
-                AzureKeyVaultServiceEndpointResourceId = AzureEnvironmentConstants.ChinaKeyVaultServiceEndpointResourceId,
-                AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = null,
-                AzureDataLakeStoreFileSystemEndpointSuffix = null,
-                DataLakeEndpointResourceId = null,
-                GraphEndpointResourceId = AzureEnvironmentConstants.ChinaGraphEndpoint,
-                BatchEndpointResourceId = AzureEnvironmentConstants.ChinaBatchEndpointResourceId,
-                ContainerRegistryEndpointSuffix = AzureEnvironmentConstants.ChinaContainerRegistryEndpointSuffix,
-                AdTenant = "Common"
-            };
-
-            var azureUSGovernment = new AzureEnvironment
-            {
-                Name = EnvironmentName.AzureUSGovernment,
-                Type = TypeBuiltIn,
-                PublishSettingsFileUrl = AzureEnvironmentConstants.USGovernmentPublishSettingsFileUrl,
-                ServiceManagementUrl = AzureEnvironmentConstants.USGovernmentServiceEndpoint,
-                ResourceManagerUrl = AzureEnvironmentConstants.USGovernmentResourceManagerEndpoint,
-                ManagementPortalUrl = AzureEnvironmentConstants.USGovernmentManagementPortalUrl,
-                ActiveDirectoryAuthority = AzureEnvironmentConstants.USGovernmentActiveDirectoryEndpoint,
-                ActiveDirectoryServiceEndpointResourceId = AzureEnvironmentConstants.USGovernmentServiceEndpoint,
-                StorageEndpointSuffix = AzureEnvironmentConstants.USGovernmentStorageEndpointSuffix,
-                GalleryUrl = AzureEnvironmentConstants.GalleryEndpoint,
-                SqlDatabaseDnsSuffix = AzureEnvironmentConstants.USGovernmentSqlDatabaseDnsSuffix,
-                GraphUrl = AzureEnvironmentConstants.USGovernmentGraphEndpoint,
-                TrafficManagerDnsSuffix = AzureEnvironmentConstants.USGovernmentTrafficManagerDnsSuffix,
-                AzureKeyVaultDnsSuffix = AzureEnvironmentConstants.USGovernmentKeyVaultDnsSuffix,
-                AzureKeyVaultServiceEndpointResourceId = AzureEnvironmentConstants.USGovernmentKeyVaultServiceEndpointResourceId,
-                AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = null,
-                AzureDataLakeStoreFileSystemEndpointSuffix = null,
-                DataLakeEndpointResourceId = null,
-                GraphEndpointResourceId = AzureEnvironmentConstants.USGovernmentGraphEndpoint,
-                BatchEndpointResourceId = AzureEnvironmentConstants.USGovernmentBatchEndpointResourceId,
-                ContainerRegistryEndpointSuffix = AzureEnvironmentConstants.USGovernmentContainerRegistryEndpointSuffix,
-                AdTenant = "Common"
-            };
 
             if (!armAzureEnvironments.ContainsKey(EnvironmentName.AzureCloud))
             {
-                armAzureEnvironments[EnvironmentName.AzureCloud] = azureCloud;
+                armAzureEnvironments[EnvironmentName.AzureCloud] = GetBuiltInAzureCloud();
             }
             if (!armAzureEnvironments.ContainsKey(EnvironmentName.AzureChinaCloud))
             {
-                armAzureEnvironments[EnvironmentName.AzureChinaCloud] = azureChina;
+                armAzureEnvironments[EnvironmentName.AzureChinaCloud] = GetBuiltInChinaAzureCloud();
             }
             if (!armAzureEnvironments.ContainsKey(EnvironmentName.AzureUSGovernment))
             {
-                armAzureEnvironments[EnvironmentName.AzureUSGovernment] = azureUSGovernment;
+                armAzureEnvironments[EnvironmentName.AzureUSGovernment] = GetBuiltInUSGovernmentCloud();
             }
 
             SetExtendedProperties(armAzureEnvironments);
@@ -200,65 +118,21 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 throw new Exception($"Failed to load cloud metadata from the url {armMetadataRequestUri}.");
             }
 
-            return JsonConvert.DeserializeObject<List<ArmMetadata>>(armMetadataContent);
-        }
-
-        /// <summary>
-        /// Set Extended properties (to maintain parity).
-        /// </summary>
-        /// <param name="azureEnvironments">Collection of AzureEnvironments</param>
-        private static void SetExtendedProperties(IDictionary<string, AzureEnvironment> azureEnvironments)
-        {
-            if (azureEnvironments.ContainsKey(EnvironmentName.AzureCloud))
+            try
             {
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpoint, AzureEnvironmentConstants.AzureOperationalInsightsEndpoint);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpointResourceId, AzureEnvironmentConstants.AzureOperationalInsightsEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointSuffix, AzureEnvironmentConstants.AzureAnalysisServicesEndpointSuffix);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.AzureAnalysisServicesEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureAttestationServiceEndpointSuffix, AzureEnvironmentConstants.AzureAttestationServiceEndpointSuffix);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureAttestationServiceEndpointResourceId, AzureEnvironmentConstants.AzureAttestationServiceEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, AzureEnvironmentConstants.AzureSynapseAnalyticsEndpointSuffix);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.AzureSynapseAnalyticsEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.AzureManagedHsmServiceEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointSuffix, AzureEnvironmentConstants.AzureManagedHsmDnsSuffix);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.MicrosoftGraphEndpointResourceId, AzureEnvironmentConstants.AzureMicrosoftGraphEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.MicrosoftGraphUrl, AzureEnvironmentConstants.AzureMicrosoftGraphUrl);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzurePurviewEndpointSuffix, AzureEnvironmentConstants.AzurePurviewEndpointSuffix);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzurePurviewEndpointResourceId, AzureEnvironmentConstants.AzurePurviewEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointSuffix, AzureEnvironmentConstants.AzureAppConfigurationEndpointSuffix);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointResourceId, AzureEnvironmentConstants.AzureAppConfigurationEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.AzureContainerRegistryEndpointResourceId);            
+                return JsonConvert.DeserializeObject<List<ArmMetadata>>(armMetadataContent);
             }
-
-            if (azureEnvironments.ContainsKey(EnvironmentName.AzureChinaCloud))
+            catch
             {
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpoint, AzureEnvironmentConstants.ChinaOperationalInsightsEndpoint);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpointResourceId, AzureEnvironmentConstants.ChinaOperationalInsightsEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointSuffix, AzureEnvironmentConstants.ChinaAnalysisServicesEndpointSuffix);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.ChinaAnalysisServicesEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, AzureEnvironmentConstants.ChinaSynapseAnalyticsEndpointSuffix);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.ChinaSynapseAnalyticsEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.ChinaManagedHsmServiceEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointSuffix, AzureEnvironmentConstants.ChinaManagedHsmDnsSuffix);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.MicrosoftGraphEndpointResourceId, AzureEnvironmentConstants.ChinaMicrosoftGraphEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.MicrosoftGraphUrl, AzureEnvironmentConstants.ChinaMicrosoftGraphUrl);
-                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.ChinaContainerRegistryEndpointResourceId);
+                var metadata = JsonConvert.DeserializeObject<ArmMetadata>(armMetadataContent);
+                if (metadata!= null)
+                {
+                    var armMetadataList = new List<ArmMetadata>();
+                    armMetadataList.Add(metadata);
+                    return armMetadataList;
+                }
             }
-
-            if (azureEnvironments.ContainsKey(EnvironmentName.AzureUSGovernment))
-            {
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.OperationalInsightsEndpoint, AzureEnvironmentConstants.USGovernmentOperationalInsightsEndpoint);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.OperationalInsightsEndpointResourceId, AzureEnvironmentConstants.USGovernmentOperationalInsightsEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointSuffix, AzureEnvironmentConstants.USGovernmentAnalysisServicesEndpointSuffix);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.USGovernmentAnalysisServicesEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, AzureEnvironmentConstants.USGovernmentSynapseAnalyticsEndpointSuffix);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.USGovernmentSynapseAnalyticsEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.USGovernmeneManagedHsmServiceEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointSuffix, AzureEnvironmentConstants.USGovernmentManagedHsmDnsSuffix);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.MicrosoftGraphEndpointResourceId, AzureEnvironmentConstants.USGovernmentMicrosoftGraphEndpointResourceId);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.MicrosoftGraphUrl, AzureEnvironmentConstants.USGovernmentMicrosoftGraphUrl);
-                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.USGovernmentContainerRegistryEndpointResourceId);
-            }
+            return null;
         }
 
         /// <summary>
@@ -313,6 +187,37 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
             {
                 azureEnvironment.ServiceManagementUrl += "/";
             }
+
+            if (!string.IsNullOrEmpty(armMetadata.MicrosoftGraphResourceId))
+            {
+                azureEnvironment.SetProperty(ExtendedEndpoint.MicrosoftGraphEndpointResourceId, armMetadata.MicrosoftGraphResourceId);
+                //Default ARM endpoint doens't provide MicrosoftGraphUrl. Keep it here just in case.
+                if (armMetadata.MicrosoftGraphResourceId.EndsWith("/"))
+                {
+                    azureEnvironment.SetProperty(ExtendedEndpoint.MicrosoftGraphUrl,
+                        armMetadata.MicrosoftGraphResourceId.TrimEnd('/'));
+                }
+            }
+
+            if (!string.IsNullOrEmpty(armMetadata.AttestationResourceId))
+            {
+                azureEnvironment.SetProperty(ExtendedEndpoint.AzureAttestationServiceEndpointResourceId, armMetadata.AttestationResourceId);
+                if (!string.IsNullOrEmpty(armMetadata.Suffixes.AttestationEndpoint))
+                {
+                    azureEnvironment.SetProperty(ExtendedEndpoint.AzureAttestationServiceEndpointSuffix, armMetadata.Suffixes.AttestationEndpoint);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(armMetadata.SynapseAnalyticsResourceId))
+            {
+                azureEnvironment.SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, armMetadata.SynapseAnalyticsResourceId);
+                if (!string.IsNullOrEmpty(armMetadata.Suffixes.SynapseAnalytics))
+                {
+                    azureEnvironment.SetProperty(ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, armMetadata.Suffixes.SynapseAnalytics);
+                }
+            }
+            //Todo:MhsmDns=ManagedHsmServiceEndpointSuffix;AzureManagedHsmServiceEndpointResourceId not provided
+            //Todo:AcrLoginServer=ContainerRegistryEndpointSuffix;ContainerRegistryEndpointResourceId not provided
 
             return azureEnvironment;
         }

--- a/src/Authentication.Abstractions/AzureEnvironmentBuiltInSettings.cs
+++ b/src/Authentication.Abstractions/AzureEnvironmentBuiltInSettings.cs
@@ -1,0 +1,202 @@
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.Common.Authentication.Abstractions.Interfaces;
+using Microsoft.Azure.Commands.Common.Authentication.Abstractions.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
+{
+    /// <summary>
+    /// The build-in endpoints settings of AzureEnvironment.
+    /// </summary>
+    public partial class AzureEnvironment
+    {
+
+        /// <summary>
+        /// Get built-in endpoints of AzureCloud.
+        /// </summary>
+        private static AzureEnvironment GetBuiltInAzureCloud()
+        {
+            var azureEnv = new AzureEnvironment
+            {
+                Name = EnvironmentName.AzureCloud,
+                Type = TypeBuiltIn,
+                PublishSettingsFileUrl = AzureEnvironmentConstants.AzurePublishSettingsFileUrl,
+                ServiceManagementUrl = AzureEnvironmentConstants.AzureServiceEndpoint,
+                ResourceManagerUrl = AzureEnvironmentConstants.AzureResourceManagerEndpoint,
+                ManagementPortalUrl = AzureEnvironmentConstants.AzureManagementPortalUrl,
+                ActiveDirectoryAuthority = AzureEnvironmentConstants.AzureActiveDirectoryEndpoint,
+                ActiveDirectoryServiceEndpointResourceId = AzureEnvironmentConstants.AzureServiceEndpoint,
+                StorageEndpointSuffix = AzureEnvironmentConstants.AzureStorageEndpointSuffix,
+                GalleryUrl = AzureEnvironmentConstants.GalleryEndpoint,
+                SqlDatabaseDnsSuffix = AzureEnvironmentConstants.AzureSqlDatabaseDnsSuffix,
+                GraphUrl = AzureEnvironmentConstants.AzureGraphEndpoint,
+                TrafficManagerDnsSuffix = AzureEnvironmentConstants.AzureTrafficManagerDnsSuffix,
+                AzureKeyVaultDnsSuffix = AzureEnvironmentConstants.AzureKeyVaultDnsSuffix,
+                AzureKeyVaultServiceEndpointResourceId = AzureEnvironmentConstants.AzureKeyVaultServiceEndpointResourceId,
+                AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = AzureEnvironmentConstants.AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix,
+                AzureDataLakeStoreFileSystemEndpointSuffix = AzureEnvironmentConstants.AzureDataLakeStoreFileSystemEndpointSuffix,
+                GraphEndpointResourceId = AzureEnvironmentConstants.AzureGraphEndpoint,
+                DataLakeEndpointResourceId = AzureEnvironmentConstants.AzureDataLakeServiceEndpointResourceId,
+                BatchEndpointResourceId = AzureEnvironmentConstants.BatchEndpointResourceId,
+                ContainerRegistryEndpointSuffix = AzureEnvironmentConstants.AzureContainerRegistryEndpointSuffix,
+                AdTenant = "Common",
+
+                ExtendedProperties = 
+                {
+                    { ExtendedEndpoint.AzureAttestationServiceEndpointSuffix, AzureEnvironmentConstants.AzureAttestationServiceEndpointSuffix },
+                    { ExtendedEndpoint.AzureAttestationServiceEndpointResourceId, AzureEnvironmentConstants.AzureAttestationServiceEndpointResourceId },
+                    { ExtendedEndpoint.MicrosoftGraphEndpointResourceId, AzureEnvironmentConstants.AzureMicrosoftGraphEndpointResourceId },
+                    { ExtendedEndpoint.MicrosoftGraphUrl, AzureEnvironmentConstants.AzureMicrosoftGraphUrl },
+                    { ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, AzureEnvironmentConstants.AzureSynapseAnalyticsEndpointSuffix },
+                    { ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.AzureSynapseAnalyticsEndpointResourceId }
+                }
+            };
+            return azureEnv;
+        }
+
+        /// <summary>
+        /// Get built-in endpoints of AzureChinaCloud.
+        /// </summary>
+        private static AzureEnvironment GetBuiltInChinaAzureCloud()
+        {
+            var azureEnv = new AzureEnvironment
+            {
+                Name = EnvironmentName.AzureChinaCloud,
+                Type = TypeBuiltIn,
+                PublishSettingsFileUrl = AzureEnvironmentConstants.ChinaPublishSettingsFileUrl,
+                ServiceManagementUrl = AzureEnvironmentConstants.ChinaServiceEndpoint,
+                ResourceManagerUrl = AzureEnvironmentConstants.ChinaResourceManagerEndpoint,
+                ManagementPortalUrl = AzureEnvironmentConstants.ChinaManagementPortalUrl,
+                ActiveDirectoryAuthority = AzureEnvironmentConstants.ChinaActiveDirectoryEndpoint,
+                ActiveDirectoryServiceEndpointResourceId = AzureEnvironmentConstants.ChinaServiceEndpoint,
+                StorageEndpointSuffix = AzureEnvironmentConstants.ChinaStorageEndpointSuffix,
+                GalleryUrl = AzureEnvironmentConstants.GalleryEndpoint,
+                SqlDatabaseDnsSuffix = AzureEnvironmentConstants.ChinaSqlDatabaseDnsSuffix,
+                GraphUrl = AzureEnvironmentConstants.ChinaGraphEndpoint,
+                TrafficManagerDnsSuffix = AzureEnvironmentConstants.ChinaTrafficManagerDnsSuffix,
+                AzureKeyVaultDnsSuffix = AzureEnvironmentConstants.ChinaKeyVaultDnsSuffix,
+                AzureKeyVaultServiceEndpointResourceId = AzureEnvironmentConstants.ChinaKeyVaultServiceEndpointResourceId,
+                AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = null,
+                AzureDataLakeStoreFileSystemEndpointSuffix = null,
+                DataLakeEndpointResourceId = null,
+                GraphEndpointResourceId = AzureEnvironmentConstants.ChinaGraphEndpoint,
+                BatchEndpointResourceId = AzureEnvironmentConstants.ChinaBatchEndpointResourceId,
+                ContainerRegistryEndpointSuffix = AzureEnvironmentConstants.ChinaContainerRegistryEndpointSuffix,
+                AdTenant = "Common",
+
+                ExtendedProperties =
+                {
+                    { ExtendedEndpoint.MicrosoftGraphEndpointResourceId, AzureEnvironmentConstants.ChinaMicrosoftGraphEndpointResourceId },
+                    { ExtendedEndpoint.MicrosoftGraphUrl, AzureEnvironmentConstants.ChinaMicrosoftGraphUrl },
+                    { ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, AzureEnvironmentConstants.ChinaSynapseAnalyticsEndpointSuffix },
+                    { ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.ChinaSynapseAnalyticsEndpointResourceId }
+                }
+            };
+            return azureEnv;
+        }
+
+        /// <summary>
+        /// Get built-in endpoints of AzureUSGovernment.
+        /// </summary>
+        private static AzureEnvironment GetBuiltInUSGovernmentCloud()
+        {
+            var azureEnv = new AzureEnvironment
+            {
+                Name = EnvironmentName.AzureUSGovernment,
+                Type = TypeBuiltIn,
+                PublishSettingsFileUrl = AzureEnvironmentConstants.USGovernmentPublishSettingsFileUrl,
+                ServiceManagementUrl = AzureEnvironmentConstants.USGovernmentServiceEndpoint,
+                ResourceManagerUrl = AzureEnvironmentConstants.USGovernmentResourceManagerEndpoint,
+                ManagementPortalUrl = AzureEnvironmentConstants.USGovernmentManagementPortalUrl,
+                ActiveDirectoryAuthority = AzureEnvironmentConstants.USGovernmentActiveDirectoryEndpoint,
+                ActiveDirectoryServiceEndpointResourceId = AzureEnvironmentConstants.USGovernmentServiceEndpoint,
+                StorageEndpointSuffix = AzureEnvironmentConstants.USGovernmentStorageEndpointSuffix,
+                GalleryUrl = AzureEnvironmentConstants.GalleryEndpoint,
+                SqlDatabaseDnsSuffix = AzureEnvironmentConstants.USGovernmentSqlDatabaseDnsSuffix,
+                GraphUrl = AzureEnvironmentConstants.USGovernmentGraphEndpoint,
+                TrafficManagerDnsSuffix = AzureEnvironmentConstants.USGovernmentTrafficManagerDnsSuffix,
+                AzureKeyVaultDnsSuffix = AzureEnvironmentConstants.USGovernmentKeyVaultDnsSuffix,
+                AzureKeyVaultServiceEndpointResourceId = AzureEnvironmentConstants.USGovernmentKeyVaultServiceEndpointResourceId,
+                AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix = null,
+                AzureDataLakeStoreFileSystemEndpointSuffix = null,
+                DataLakeEndpointResourceId = null,
+                GraphEndpointResourceId = AzureEnvironmentConstants.USGovernmentGraphEndpoint,
+                BatchEndpointResourceId = AzureEnvironmentConstants.USGovernmentBatchEndpointResourceId,
+                ContainerRegistryEndpointSuffix = AzureEnvironmentConstants.USGovernmentContainerRegistryEndpointSuffix,
+                AdTenant = "Common",
+
+                ExtendedProperties =
+                {
+                    { ExtendedEndpoint.MicrosoftGraphEndpointResourceId, AzureEnvironmentConstants.USGovernmentMicrosoftGraphEndpointResourceId },
+                    { ExtendedEndpoint.MicrosoftGraphUrl, AzureEnvironmentConstants.USGovernmentMicrosoftGraphUrl },
+                    { ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, AzureEnvironmentConstants.USGovernmentSynapseAnalyticsEndpointSuffix },
+                    { ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.USGovernmentAnalysisServicesEndpointResourceId }
+                }
+            };
+            return azureEnv;
+        }
+
+        /// <summary>
+        /// Set Extended properties (to maintain parity).
+        /// </summary>
+        /// <param name="azureEnvironments">Collection of AzureEnvironments</param>
+        private static void SetExtendedProperties(IDictionary<string, AzureEnvironment> azureEnvironments)
+        {
+            if (azureEnvironments.ContainsKey(EnvironmentName.AzureCloud))
+            {
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpoint, AzureEnvironmentConstants.AzureOperationalInsightsEndpoint);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpointResourceId, AzureEnvironmentConstants.AzureOperationalInsightsEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointSuffix, AzureEnvironmentConstants.AzureAnalysisServicesEndpointSuffix);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.AzureAnalysisServicesEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.AzureManagedHsmServiceEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointSuffix, AzureEnvironmentConstants.AzureManagedHsmDnsSuffix);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzurePurviewEndpointSuffix, AzureEnvironmentConstants.AzurePurviewEndpointSuffix);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzurePurviewEndpointResourceId, AzureEnvironmentConstants.AzurePurviewEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointSuffix, AzureEnvironmentConstants.AzureAppConfigurationEndpointSuffix);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointResourceId, AzureEnvironmentConstants.AzureAppConfigurationEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.AzureContainerRegistryEndpointResourceId);            
+            }
+
+            if (azureEnvironments.ContainsKey(EnvironmentName.AzureChinaCloud))
+            {
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpoint, AzureEnvironmentConstants.ChinaOperationalInsightsEndpoint);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.OperationalInsightsEndpointResourceId, AzureEnvironmentConstants.ChinaOperationalInsightsEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointSuffix, AzureEnvironmentConstants.ChinaAnalysisServicesEndpointSuffix);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.ChinaAnalysisServicesEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.ChinaManagedHsmServiceEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointSuffix, AzureEnvironmentConstants.ChinaManagedHsmDnsSuffix);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.ChinaContainerRegistryEndpointResourceId);
+            }
+
+            if (azureEnvironments.ContainsKey(EnvironmentName.AzureUSGovernment))
+            {
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.OperationalInsightsEndpoint, AzureEnvironmentConstants.USGovernmentOperationalInsightsEndpoint);
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.OperationalInsightsEndpointResourceId, AzureEnvironmentConstants.USGovernmentOperationalInsightsEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointSuffix, AzureEnvironmentConstants.USGovernmentAnalysisServicesEndpointSuffix);
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.USGovernmentAnalysisServicesEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.USGovernmeneManagedHsmServiceEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointSuffix, AzureEnvironmentConstants.USGovernmentManagedHsmDnsSuffix);
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.USGovernmentContainerRegistryEndpointResourceId);
+            }
+        } 
+    }
+}

--- a/src/Authentication.Abstractions/Models/ArmMetadata.cs
+++ b/src/Authentication.Abstractions/Models/ArmMetadata.cs
@@ -87,5 +87,40 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions.Models
         /// Gets or sets the Gallery endpoint.
         /// </summary>
         public string Gallery { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MicrosoftGraph endpoint.
+        /// </summary>
+        public string MicrosoftGraphResourceId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ApplicationInsight endpoint.
+        /// </summary>
+        public string AppInsightsResourceId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ApplicationInsightsTelemetryChannel endpoint.
+        /// </summary>
+        public string AppInsightsTelemetryChannelResourceId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Attestation endpoint.
+        /// </summary>
+        public string AttestationResourceId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SynapseAnalytics endpoint.
+        /// </summary>
+        public string SynapseAnalyticsResourceId { set; get; }
+
+        /// <summary>
+        /// Gets or sets the LogAnalytics endpoint.
+        /// </summary>
+        public string LogAnalyticsResourceId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OssrDbms endpoint.
+        /// </summary>
+        public string OssrDbmsResourceId { get; set; }
     }
 }

--- a/src/Authentication.Abstractions/Models/SuffixEndpoints.cs
+++ b/src/Authentication.Abstractions/Models/SuffixEndpoints.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions.Models
     {
         /// <summary>
         /// Gets or sets the AzureDataLakeStoreFileSystem endpoint.
-        /// </summary>        
+        /// </summary>
         public string AzureDataLakeStoreFileSystem { get; set; }
 
         /// <summary>
@@ -48,5 +48,45 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions.Models
         /// Gets or sets the Storage endpoint.
         /// </summary>
         public string Storage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Azure FrontDoor endpoint.
+        /// </summary>
+        public string AzureFrontDoorEndpointSuffix { get; set; }
+
+        /// <summary>
+        /// Gets or sets the StorageSync endpoint.
+        /// </summary>
+        public string StorageSyncEndpointSuffix { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ManagedHSM endpoint.
+        /// </summary>
+        public string MhsmDns { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MySqlServer endpoint.
+        /// </summary>
+        public string MysqlServerEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the PostgresqlServer endpoint.
+        /// </summary>
+        public string PostgresqlServerEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MariadbServer endpoint.
+        /// </summary>
+        public string MariadbServerEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SynapseAnalytics endpoint.
+        /// </summary>
+        public string SynapseAnalytics { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Attestation endpoint.
+        /// </summary>
+        public string AttestationEndpoint { get; set; }
     }
 }


### PR DESCRIPTION
ArmMetadata with API version 2022-09-01 has changed the response format from array to single object. Also properties in the metadata are also changed.
![image](https://user-images.githubusercontent.com/54836179/220711881-26742def-5882-4020-8eea-a474a315c539.png)

- Update the related code to support new format of metadata
- Use the properties in the metadata to update the endpoints of MicrosoftGraph, Attestation and SynapseAnalytics endpoints
- Fix the target framework issue of test projects
