### PR TITLE
Interface for collection parameter values

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -19,6 +19,7 @@ using Microsoft.Azure.PowerShell.Common.Share.Survey;
 using Microsoft.Azure.ServiceManagement.Common.Models;
 using Microsoft.WindowsAzure.Commands.Common;
 using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
+using Microsoft.WindowsAzure.Commands.Common.Utilities;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -702,9 +703,16 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             if (this.MyInvocation != null && this.MyInvocation.BoundParameters != null
                 && this.MyInvocation.BoundParameters.Keys != null)
             {
-                _qosEvent.Parameters = string.Join(" ",
-                    this.MyInvocation.BoundParameters.Keys.Select(
-                        s => string.Format(CultureInfo.InvariantCulture, "-{0} ***", s)));
+                if (AzureSession.Instance.TryGetComponent<IParameterTelemetryFormatter>(nameof(IParameterTelemetryFormatter), out var formatter))
+                {
+                    _qosEvent.Parameters = formatter.FormatParameters(MyInvocation.BoundParameters);
+                }
+                else
+                {
+                    _qosEvent.Parameters = string.Join(" ",
+                        this.MyInvocation.BoundParameters.Keys.Select(
+                            s => string.Format(CultureInfo.InvariantCulture, "-{0} ***", s)));
+                }
             }
         }
 

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -705,7 +705,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             {
                 if (AzureSession.Instance.TryGetComponent<IParameterTelemetryFormatter>(nameof(IParameterTelemetryFormatter), out var formatter))
                 {
-                    _qosEvent.Parameters = formatter.FormatParameters(MyInvocation.BoundParameters);
+                    _qosEvent.Parameters = formatter.FormatParameters(MyInvocation);
                 }
                 else
                 {

--- a/src/Common/Telemetry/IParameterTelemetryFormatter.cs
+++ b/src/Common/Telemetry/IParameterTelemetryFormatter.cs
@@ -13,6 +13,7 @@
 // ----------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Management.Automation;
 
 namespace Microsoft.WindowsAzure.Commands.Common.Utilities
 {
@@ -24,8 +25,8 @@ namespace Microsoft.WindowsAzure.Commands.Common.Utilities
         /// <summary>
         /// Format the bound parameters to a string without sensitive data.
         /// </summary>
-        /// <param name="boundParameters">Used parameters of current invocation.</param>
+        /// <param name="invocation">Info about cmdlet invocation</param>
         /// <returns>The formatted string.</returns>
-        string FormatParameters(IDictionary<string, object> boundParameters);
+        string FormatParameters(InvocationInfo invocation);
     }
 }

--- a/src/Common/Telemetry/IParameterTelemetryFormatter.cs
+++ b/src/Common/Telemetry/IParameterTelemetryFormatter.cs
@@ -1,0 +1,31 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.WindowsAzure.Commands.Common.Utilities
+{
+    /// <summary>
+    /// String formatter for bound parameters for telemetry purpose.
+    /// </summary>
+    public interface IParameterTelemetryFormatter
+    {
+        /// <summary>
+        /// Format the bound parameters to a string without sensitive data.
+        /// </summary>
+        /// <param name="boundParameters">Used parameters of current invocation.</param>
+        /// <returns>The formatted string.</returns>
+        string FormatParameters(IDictionary<string, object> boundParameters);
+    }
+}


### PR DESCRIPTION
This PR contains the interface definition for an utility to format PSBoundParameters (including names and values) to a string. The string will be included in the client-side telemetry.