### PR TITLE
Missing DefaultArmMetaDataEndpoint assignment

### DIFF
--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -44,7 +44,11 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 if (string.IsNullOrEmpty(armMetadataRequestUri))
                 {
                     armMetadataRequestUri = Environment.GetEnvironmentVariable(ArmMetadataEnvVariable);
-                    if (!string.IsNullOrEmpty(armMetadataRequestUri))
+                    if (string.IsNullOrEmpty(armMetadataRequestUri))
+                    {
+                        armMetadataRequestUri = DefaultArmMetaDataEndpoint;
+                    }
+                    else
                     {
                         debugLogger?.Invoke($"Get {armMetadataRequestUri} from environment variable {ArmMetadataEnvVariable}");
                     }


### PR DESCRIPTION
DefaultArmMetaDataEndpoint assignment is removed in https://github.com/Azure/azure-powershell-common/pull/374
Revert the incorrect change in https://github.com/Azure/azure-powershell-common/pull/374
