### PR TITLE
Fix the incorrect AzureSynapseAnalyticsEndpointResourceId of USGovernment

### DIFF
--- a/src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                     { ExtendedEndpoint.MicrosoftGraphEndpointResourceId, AzureEnvironmentConstants.USGovernmentMicrosoftGraphEndpointResourceId },
                     { ExtendedEndpoint.MicrosoftGraphUrl, AzureEnvironmentConstants.USGovernmentMicrosoftGraphUrl },
                     { ExtendedEndpoint.AzureSynapseAnalyticsEndpointSuffix, AzureEnvironmentConstants.USGovernmentSynapseAnalyticsEndpointSuffix },
-                    { ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.USGovernmentAnalysisServicesEndpointResourceId }
+                    { ExtendedEndpoint.AzureSynapseAnalyticsEndpointResourceId, AzureEnvironmentConstants.USGovernmentSynapseAnalyticsEndpointResourceId }
                 }
             };
         }


### PR DESCRIPTION
Change the current wrong endpoint `https://region.asazure.usgovcloudapi.net` to `https://dev.azuresynapse.usgovcloudapi.net`

Test: https://github.com/Azure/azure-powershell/pull/21516