### PR TITLE
Check null reference cases for version upgrade notification

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -16,7 +16,7 @@ using Microsoft.Azure.Commands.Common.Authentication;
 using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
 using Microsoft.Azure.PowerShell.Common.Config;
 using Microsoft.Azure.PowerShell.Common.Share.Survey;
-using Microsoft.Azure.PowerShell.Common.Share.UpgradeNotification;
+using Microsoft.Azure.PowerShell.Common.UpgradeNotification;
 using Microsoft.Azure.ServiceManagement.Common.Models;
 using Microsoft.WindowsAzure.Commands.Common;
 using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;

--- a/src/Common/Properties/Resources.Designer.cs
+++ b/src/Common/Properties/Resources.Designer.cs
@@ -651,6 +651,15 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There will be breaking changes from {0} to {1}. Open {2} and check the details..
+        /// </summary>
+        public static string BreakingChangesMessage {
+            get {
+                return ResourceManager.GetString("BreakingChangesMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to CACHERUNTIMEURL.
         /// </summary>
         public static string CacheRuntimeUrl {
@@ -2011,6 +2020,15 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         public static string ManifestUri {
             get {
                 return ResourceManager.GetString("ManifestUri", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to https://go.microsoft.com/fwlink/?linkid=2241373.
+        /// </summary>
+        public static string MigrationGuideLink {
+            get {
+                return ResourceManager.GetString("MigrationGuideLink", resourceCulture);
             }
         }
         
@@ -4435,6 +4453,17 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         public static string UserNameNeedsToBeSpecified {
             get {
                 return ResourceManager.GetString("UserNameNeedsToBeSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You&apos;re using {0} version {1}. The latest version of {0} is {2}. Upgrade your Az modules using the following commands:
+        ///  {3} {4} -WhatIf    -- Simulate updating your Az modules.
+        ///  {3} {4}            -- Update your Az modules..
+        /// </summary>
+        public static string VersionUpgradeMessage {
+            get {
+                return ResourceManager.GetString("VersionUpgradeMessage", resourceCulture);
             }
         }
         

--- a/src/Common/Properties/Resources.resx
+++ b/src/Common/Properties/Resources.resx
@@ -1742,4 +1742,15 @@ Note : Go to {0} for steps to suppress this breaking change warning, and other i
   <data name="PreviewCmdletETAMessage" xml:space="preserve">
     <value> The estimated generally available date is '{0}'.</value>
   </data>
+  <data name="BreakingChangesMessage" xml:space="preserve">
+    <value>There will be breaking changes from {0} to {1}. Open {2} and check the details.</value>
+  </data>
+  <data name="MigrationGuideLink" xml:space="preserve">
+    <value>https://go.microsoft.com/fwlink/?linkid=2241373</value>
+  </data>
+  <data name="VersionUpgradeMessage" xml:space="preserve">
+    <value>You're using {0} version {1}. The latest version of {0} is {2}. Upgrade your Az modules using the following commands:
+  {3} {4} -WhatIf    -- Simulate updating your Az modules.
+  {3} {4}            -- Update your Az modules.</value>
+  </data>
 </root>


### PR DESCRIPTION
- In test env, the parameters for the version upgrade notification method could be null. Skip the exceptional cases.
- Move the warning message from the code to ResourceManager.