### PR TITLE
Add module name to breaking changes

### DIFF
--- a/src/Common/CustomAttributes/BreakingChangeAttributeHelper.cs
+++ b/src/Common/CustomAttributes/BreakingChangeAttributeHelper.cs
@@ -89,13 +89,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
 
                 foreach (GenericBreakingChangeWithVersionAttribute attribute in attributes)
                 {
-                    if (invocationInfo != null && invocationInfo.MyCommand != null && invocationInfo.MyCommand.ModuleName != null)
-                    {
-                        attribute.PrintCustomAttributeInfo(type, false, invocationInfo.MyCommand.ModuleName, appendBreakingChangeInfo);
-                    }
-                    else {
-                        attribute.PrintCustomAttributeInfo(type, false, appendBreakingChangeInfo);
-                    }
+                    attribute.PrintCustomAttributeInfo(type, false, invocationInfo?.MyCommand?.ModuleName, appendBreakingChangeInfo);
                 }
 
                 appendBreakingChangeInfo(string.Format(Resources.BreakingChangesAttributesFooterMessage, BREAKING_CHANGE_ATTRIBUTE_INFORMATION_LINK));
@@ -131,14 +125,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
             //bound params anyways
             foreach (GenericBreakingChangeWithVersionAttribute attribute in GetAllBreakingChangeAttributesInType(type, null))
             {
-                if (invocationInfo != null && invocationInfo.MyCommand != null && invocationInfo.MyCommand.ModuleName != null)
-                {
-                    messages.Add(attribute.GetBreakingChangeTextFromAttribute(type, true, invocationInfo.MyCommand.ModuleName));
-                }
-                else {
-                    messages.Add(attribute.GetBreakingChangeTextFromAttribute(type, true));
-                }
-                
+                messages.Add(attribute.GetBreakingChangeTextFromAttribute(type, true, invocationInfo?.MyCommand?.ModuleName));
             }
 
             return messages;

--- a/src/Common/CustomAttributes/BreakingChangeAttributeHelper.cs
+++ b/src/Common/CustomAttributes/BreakingChangeAttributeHelper.cs
@@ -89,7 +89,13 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
 
                 foreach (GenericBreakingChangeWithVersionAttribute attribute in attributes)
                 {
-                    attribute.PrintCustomAttributeInfo(type, false, appendBreakingChangeInfo);
+                    if (invocationInfo != null && invocationInfo.MyCommand != null && invocationInfo.MyCommand.ModuleName != null)
+                    {
+                        attribute.PrintCustomAttributeInfo(type, false, invocationInfo.MyCommand.ModuleName, appendBreakingChangeInfo);
+                    }
+                    else {
+                        attribute.PrintCustomAttributeInfo(type, false, appendBreakingChangeInfo);
+                    }
                 }
 
                 appendBreakingChangeInfo(string.Format(Resources.BreakingChangesAttributesFooterMessage, BREAKING_CHANGE_ATTRIBUTE_INFORMATION_LINK));
@@ -112,6 +118,27 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
             foreach (GenericBreakingChangeWithVersionAttribute attribute in GetAllBreakingChangeAttributesInType(type, null))
             {
                 messages.Add(attribute.GetBreakingChangeTextFromAttribute(type, true));
+            }
+
+            return messages;
+        }
+
+        public static List<string> GetBreakingChangeMessagesForType(Type type, InvocationInfo invocationInfo)
+        {
+            List<string> messages = new List<string>();
+
+            //This is used as a migration guide, we need to process all properties/fields, moreover at this point of time we do not have a list of all the
+            //bound params anyways
+            foreach (GenericBreakingChangeWithVersionAttribute attribute in GetAllBreakingChangeAttributesInType(type, null))
+            {
+                if (invocationInfo != null && invocationInfo.MyCommand != null && invocationInfo.MyCommand.ModuleName != null)
+                {
+                    messages.Add(attribute.GetBreakingChangeTextFromAttribute(type, true, invocationInfo.MyCommand.ModuleName));
+                }
+                else {
+                    messages.Add(attribute.GetBreakingChangeTextFromAttribute(type, true));
+                }
+                
             }
 
             return messages;

--- a/src/Common/CustomAttributes/GenericBreakingChangeWithVersionAttribute.cs
+++ b/src/Common/CustomAttributes/GenericBreakingChangeWithVersionAttribute.cs
@@ -83,7 +83,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
             return GetBreakingChangeTextFromAttributeInternal(type, withCmdletName, null);
         }
 
-        public string GetBreakingChangeTextFromAttribute(Type type, bool withCmdletName, String moduleName)
+        internal string GetBreakingChangeTextFromAttribute(Type type, bool withCmdletName, String moduleName)
         {
             return GetBreakingChangeTextFromAttributeInternal(type, withCmdletName, moduleName);
         }
@@ -118,7 +118,8 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
                 {
                     breakingChangeMessage.Append(string.Format(Resources.BreakingChangesAttributesInEffectByVersion2, moduleName, this.DeprecateByVersion));
                 }
-                else {
+                else 
+                {
                     breakingChangeMessage.Append(string.Format(Resources.BreakingChangesAttributesInEffectByVersion, this.DeprecateByVersion));
                 }
             }
@@ -143,7 +144,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
             PrintCustomAttributeInfoInternal(type, withCmdletName, null, writeOutput);
         }
 
-        public void PrintCustomAttributeInfo(Type type, bool withCmdletName, String moduleName, Action<string> writeOutput)
+        internal void PrintCustomAttributeInfo(Type type, bool withCmdletName, String moduleName, Action<string> writeOutput)
         {
             PrintCustomAttributeInfoInternal(type, withCmdletName, moduleName, writeOutput);
         }
@@ -179,7 +180,8 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
             {
                 writeOutput(string.Format(Resources.BreakingChangesAttributesInEffectByVersion2, moduleName, this.DeprecateByVersion));
             }
-            else {
+            else 
+            {
                 writeOutput(string.Format(Resources.BreakingChangesAttributesInEffectByVersion, this.DeprecateByVersion));
             }
 

--- a/src/Common/CustomAttributes/GenericBreakingChangeWithVersionAttribute.cs
+++ b/src/Common/CustomAttributes/GenericBreakingChangeWithVersionAttribute.cs
@@ -80,6 +80,16 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
          */
         public string GetBreakingChangeTextFromAttribute(Type type, bool withCmdletName)
         {
+            return GetBreakingChangeTextFromAttributeInternal(type, withCmdletName, null);
+        }
+
+        public string GetBreakingChangeTextFromAttribute(Type type, bool withCmdletName, String moduleName)
+        {
+            return GetBreakingChangeTextFromAttributeInternal(type, withCmdletName, moduleName);
+        }
+
+        private string GetBreakingChangeTextFromAttributeInternal(Type type, bool withCmdletName, String moduleName)
+        {
             StringBuilder breakingChangeMessage = new StringBuilder();
 
             if (!withCmdletName)
@@ -104,7 +114,13 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
 
             if (!string.IsNullOrWhiteSpace(DeprecateByVersion))
             {
-                breakingChangeMessage.Append(string.Format(Resources.BreakingChangesAttributesInEffectByVersion, this.DeprecateByVersion));
+                if (moduleName != null)
+                {
+                    breakingChangeMessage.Append(string.Format(Resources.BreakingChangesAttributesInEffectByVersion2, moduleName, this.DeprecateByVersion));
+                }
+                else {
+                    breakingChangeMessage.Append(string.Format(Resources.BreakingChangesAttributesInEffectByVersion, this.DeprecateByVersion));
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(OldWay) && !string.IsNullOrWhiteSpace(NewWay))
@@ -123,6 +139,16 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
         * We get the cmdlet name from the passed in Type (it is expected to have the Cmdlet attribute decorated on the class)
         * */
         public void PrintCustomAttributeInfo(Type type, bool withCmdletName, Action<string> writeOutput)
+        {
+            PrintCustomAttributeInfoInternal(type, withCmdletName, null, writeOutput);
+        }
+
+        public void PrintCustomAttributeInfo(Type type, bool withCmdletName, String moduleName, Action<string> writeOutput)
+        {
+            PrintCustomAttributeInfoInternal(type, withCmdletName, moduleName, writeOutput);
+        }
+
+        private void PrintCustomAttributeInfoInternal(Type type, bool withCmdletName, String moduleName, Action<string> writeOutput)
         {
             if (!withCmdletName)
             {
@@ -146,11 +172,17 @@ namespace Microsoft.WindowsAzure.Commands.Common.CustomAttributes
             {
                 writeOutput(string.Format(Resources.BreakingChangesAttributesInEffectByDateMessage, this.ChangeInEffectByDate.ToShortDateString()));
             }
-            
+
             writeOutput(string.Format(Resources.BreakingChangesAttributesInEffectByAzVersion, this.DeprecateByAzVersion));
-            
-            writeOutput(string.Format(Resources.BreakingChangesAttributesInEffectByVersion, this.DeprecateByVersion));
-            
+
+            if (moduleName != null)
+            {
+                writeOutput(string.Format(Resources.BreakingChangesAttributesInEffectByVersion2, moduleName, this.DeprecateByVersion));
+            }
+            else {
+                writeOutput(string.Format(Resources.BreakingChangesAttributesInEffectByVersion, this.DeprecateByVersion));
+            }
+
             if (OldWay != null && NewWay != null)
             {
                 writeOutput(string.Format(Resources.BreakingChangesAttributesUsageChangeMessageConsole, OldWay, NewWay));

--- a/src/Common/Properties/Resources.Designer.cs
+++ b/src/Common/Properties/Resources.Designer.cs
@@ -623,6 +623,16 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 
+        ///- The change is expected to take effect from {0} version : &apos;{1}&apos;.
+        /// </summary>
+        public static string BreakingChangesAttributesInEffectByVersion2 {
+            get {
+                return ResourceManager.GetString("BreakingChangesAttributesInEffectByVersion2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ```powershell
         ///# Old
         ///{0}

--- a/src/Common/Properties/Resources.Designer.cs
+++ b/src/Common/Properties/Resources.Designer.cs
@@ -594,7 +594,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///- The change is expected to take effect from Az version : &apos;{0}&apos;.
+        ///- The change is expected to take effect in Az version : &apos;{0}&apos;.
         /// </summary>
         public static string BreakingChangesAttributesInEffectByAzVersion {
             get {
@@ -614,7 +614,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///- The change is expected to take effect from version : &apos;{0}&apos;.
+        ///- The change is expected to take effect in version : &apos;{0}&apos;.
         /// </summary>
         public static string BreakingChangesAttributesInEffectByVersion {
             get {
@@ -624,7 +624,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///- The change is expected to take effect from {0} version : &apos;{1}&apos;.
+        ///- The change is expected to take effect in {0} version : &apos;{1}&apos;.
         /// </summary>
         public static string BreakingChangesAttributesInEffectByVersion2 {
             get {

--- a/src/Common/Properties/Resources.resx
+++ b/src/Common/Properties/Resources.resx
@@ -1753,4 +1753,8 @@ Note : Go to {0} for steps to suppress this breaking change warning, and other i
   {3} {4} -WhatIf    -- Simulate updating your Az modules.
   {3} {4}            -- Update your Az modules.</value>
   </data>
+  <data name="BreakingChangesAttributesInEffectByVersion2" xml:space="preserve">
+    <value>
+- The change is expected to take effect from {0} version : '{1}'</value>
+  </data>
 </root>

--- a/src/Common/Properties/Resources.resx
+++ b/src/Common/Properties/Resources.resx
@@ -1702,7 +1702,7 @@ Use the Enable-AzureDataCollection cmdlet to turn the feature On. The cmdlet can
   </data>
   <data name="BreakingChangesAttributesInEffectByVersion" xml:space="preserve">
     <value>
-- The change is expected to take effect from version : '{0}'</value>
+- The change is expected to take effect in version : '{0}'</value>
   </data>
   <data name="BreakingChangesAttributesUsageChangeMessage" xml:space="preserve">
     <value>```powershell
@@ -1737,7 +1737,7 @@ Note : Go to {0} for steps to suppress this breaking change warning, and other i
   </data>
   <data name="BreakingChangesAttributesInEffectByAzVersion" xml:space="preserve">
     <value>
-- The change is expected to take effect from Az version : '{0}'</value>
+- The change is expected to take effect in Az version : '{0}'</value>
   </data>
   <data name="PreviewCmdletETAMessage" xml:space="preserve">
     <value> The estimated generally available date is '{0}'.</value>
@@ -1755,6 +1755,6 @@ Note : Go to {0} for steps to suppress this breaking change warning, and other i
   </data>
   <data name="BreakingChangesAttributesInEffectByVersion2" xml:space="preserve">
     <value>
-- The change is expected to take effect from {0} version : '{1}'</value>
+- The change is expected to take effect in {0} version : '{1}'</value>
   </data>
 </root>


### PR DESCRIPTION
This PR will add module name to breaking change message.
The message is updated from 
`The change is expected to take effect from version : '<module version>'` 
to 
`The change is expected to take effect from <module name> version : '<module version>'`

Before this change, the breaking change message looks like
```powershell
PS /> Get-AzPolicyDefinition -Name ******
WARNING: Upcoming breaking changes in the cmdlet 'Get-AzPolicyDefinition' :

- The output type 'Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.Policy.PsPolicyDefinition' is changing
- The following properties in the output type are being deprecated : 'Properties'
- The following properties are being added to the output type : 'Description' 'DisplayName' 'Metadata' 'Mode' 'Parameters' 'PolicyRule' 'PolicyType'
- The change is expected to take effect from Az version : '11.0.0'
- The change is expected to take effect from version : '7.0.0'
Note : Go to https://aka.ms/azps-changewarnings for steps to suppress this breaking change warning, and other information on breaking changes in Azure PowerShell.
```

After this change, the breaking change message looks like
```powershell
PS /test> Get-AzPolicyDefinition -Name ******
WARNING: Upcoming breaking changes in the cmdlet 'Get-AzPolicyDefinition' :

- The output type 'Microsoft.Azure.Commands.ResourceManager.Cmdlets.Implementation.Policy.PsPolicyDefinition' is changing
- The following properties in the output type are being deprecated : 'Properties'
- The following properties are being added to the output type : 'Description' 'DisplayName' 'Metadata' 'Mode' 'Parameters' 'PolicyRule' 'PolicyType'
- The change is expected to take effect from Az version : '11.0.0'
- The change is expected to take effect from Az.Resources version : '7.0.0'
Note : Go to https://aka.ms/azps-changewarnings for steps to suppress this breaking change warning, and other information on breaking changes in Azure PowerShell.
```