### PR TITLE
Add WriteInformation Method in AzurePSCmdlet

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -57,12 +57,6 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
         protected IList<Regex> _matchers { get;  private set; }  = new List<Regex>();
         private static readonly Regex _defaultMatcher = new Regex("(\\s*\"access_token\"\\s*:\\s*)\"[^\"]+\"");
 
-        // Using Ansi Code to control font color(97(Bold White)) and background color(0;120;212(RGB))
-        private static readonly string ansiCodePrefix = "\u001b[97;48;2;0;120;212m";
-
-        // using '[k' for erase in line. '[0m' to ending ansi code
-        private static readonly string ansiCodeSuffix = "\u001b[K\u001b[0m";
-
         protected AzurePSDataCollectionProfile _dataCollectionProfile
         {
             get
@@ -468,12 +462,12 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             var link = "'Open-AzSurveyLink'";
             var action = " to open in browser. Learn more at ";
             var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
-            WriteInformationWrappedByAnsiCode(newLine);
-            WriteInformationWrappedByAnsiCode(howWas, true);
-            WriteInformationWrappedByAnsiCode(link, true);
-            WriteInformationWrappedByAnsiCode(action, true);
-            WriteInformationWrappedByAnsiCode(website, true);
-            WriteInformationWrappedByAnsiCode(newLine);
+            WriteHighlightedInformation(newLine);
+            WriteHighlightedInformation(howWas, true);
+            WriteHighlightedInformation(link, true);
+            WriteHighlightedInformation(action, true);
+            WriteHighlightedInformation(website, true);
+            WriteHighlightedInformation(newLine);
         }
 
         protected new void WriteError(ErrorRecord errorRecord)
@@ -534,12 +528,6 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
         {
             FlushDebugMessages();
             base.WriteInformation(messageData, tags);
-        }
-
-        protected void WriteInformationWrappedByAnsiCode(string text, bool? noNewLine = null)
-        {
-            HostInformationMessage message = new HostInformationMessage { Message = ansiCodePrefix + text + ansiCodeSuffix, NoNewLine = noNewLine };
-            WriteInformation(message, new string[1] { "PSHOST" });
         }
 
         protected void WriteHighlightedInformation(string text, bool? noNewLine = null)

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -551,6 +551,19 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             base.WriteWarning(text);
         }
 
+        protected new void WriteInformation(object messageData, string[] tags)
+        {
+            FlushDebugMessages();
+            base.WriteInformation(messageData, tags);
+        }
+
+        protected void WriteInformation(string text)
+        {
+            FlushDebugMessages();
+            HostInformationMessage message = new HostInformationMessage { Message = ansiCodePrefix + text + ansiCodeSuffix, NoNewLine = false };
+            base.WriteInformation(message, new string[1] {"PSHOST"});
+        }
+
         protected new void WriteCommandDetail(string text)
         {
             FlushDebugMessages();
@@ -590,6 +603,14 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             if (CommandRuntime != null)
             {
                 WriteWarning(string.Format("{0:T} - {1}", DateTime.Now, message));
+            }
+        }
+
+        protected void WriteInformationWithTimestamp(string message)
+        {
+            if (CommandRuntime != null)
+            {
+                WriteInformation(string.Format("{0:T} - {1}", DateTime.Now, message));
             }
         }
 

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -468,12 +468,12 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             var link = "'Open-AzSurveyLink'";
             var action = " to open in browser. Learn more at ";
             var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
-            WriteInformationWithAnsiCodeStyle(newLine);
-            WriteInformationWithAnsiCodeStyle(howWas, true);
-            WriteInformationWithAnsiCodeStyle(link, true);
-            WriteInformationWithAnsiCodeStyle(action, true);
-            WriteInformationWithAnsiCodeStyle(website, true);
-            WriteInformationWithAnsiCodeStyle(newLine);
+            WriteInformationWrappedByAnsiCode(newLine);
+            WriteInformationWrappedByAnsiCode(howWas, true);
+            WriteInformationWrappedByAnsiCode(link, true);
+            WriteInformationWrappedByAnsiCode(action, true);
+            WriteInformationWrappedByAnsiCode(website, true);
+            WriteInformationWrappedByAnsiCode(newLine);
         }
 
         protected new void WriteError(ErrorRecord errorRecord)
@@ -536,9 +536,15 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             base.WriteInformation(messageData, tags);
         }
 
-        protected void WriteInformationWithAnsiCodeStyle(string text, bool? noNewLine = null)
+        protected void WriteInformationWrappedByAnsiCode(string text, bool? noNewLine = null)
         {
             HostInformationMessage message = new HostInformationMessage { Message = ansiCodePrefix + text + ansiCodeSuffix, NoNewLine = noNewLine };
+            WriteInformation(message, new string[1] { "PSHOST" });
+        }
+
+        protected void WriteHighlightedInformation(string text, bool? noNewLine = null)
+        {
+            HostInformationMessage message = new HostInformationMessage { Message = text, NoNewLine = noNewLine, BackgroundColor = ConsoleColor.Blue, ForegroundColor = ConsoleColor.White };
             WriteInformation(message, new string[1] { "PSHOST" });
         }
 

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -458,9 +458,14 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 
         protected void WriteSurvey()
         {
+            // Using color same with Azure brand event. 
+            // Using Ansi Code to control font color(97(Bold White)) and background color(0;120;212(RGB))
+            string ansiCodePrefix = "\u001b[97;48;2;0;120;212m";
+            // using '[k' for erase in line. '[0m' to ending ansi code
+            string ansiCodeSuffix = "\u001b[K\u001b[0m";
             var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
-            WriteHighlightedInformation(Environment.NewLine);
-            WriteHighlightedInformation(string.Format(Resources.SurveyPreface, website), false);
+            WriteStringAsInformation(Environment.NewLine);
+            WriteStringAsInformation(ansiCodePrefix+string.Format(Resources.SurveyPreface, website)+ ansiCodeSuffix, false);
         }
 
         protected new void WriteError(ErrorRecord errorRecord)
@@ -523,7 +528,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             base.WriteInformation(messageData, tags);
         }
 
-        protected void WriteHighlightedInformation(string text, bool? noNewLine = null)
+        protected void WriteStringAsInformation(string text, bool? noNewLine = null)
         {
             HostInformationMessage message = new HostInformationMessage { Message = text, NoNewLine = noNewLine, BackgroundColor = ConsoleColor.Blue, ForegroundColor = ConsoleColor.White };
             WriteInformation(message, new string[1] { "PSHOST" });

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -464,8 +464,8 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             // using '[k' for erase in line. '[0m' to ending ansi code
             string ansiCodeSuffix = "\u001b[K\u001b[0m";
             var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
-            WriteStringInformation(Environment.NewLine);
-            WriteStringInformation(ansiCodePrefix + string.Format(Resources.SurveyPreface, website) + ansiCodeSuffix, false);
+            WriteInformationToPsHost(Environment.NewLine);
+            WriteInformationToPsHost(ansiCodePrefix + string.Format(Resources.SurveyPreface, website) + ansiCodeSuffix, false);
         }
 
         protected new void WriteError(ErrorRecord errorRecord)
@@ -528,7 +528,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             base.WriteInformation(messageData, tags);
         }
 
-        protected void WriteStringInformation(string text, bool? noNewLine = null)
+        protected void WriteInformationToPsHost(string text, bool? noNewLine = null)
         {
             HostInformationMessage message = new HostInformationMessage { Message = text, NoNewLine = noNewLine };
             WriteInformation(message, new string[1] { "PSHOST" });

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -463,39 +463,17 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 
         protected void WriteSurvey()
         {
-            HostInformationMessage newLine = new HostInformationMessage()
-            {
-                Message = ansiCodePrefix + "\n" + ansiCodeSuffix
-            };
-            HostInformationMessage howWas = new HostInformationMessage()
-            {
-                Message = ansiCodePrefix + "[Survey] Help us improve Azure PowerShell by sharing your experience. This survey should take about 5 minutes. Run "+ ansiCodeSuffix,
-                NoNewLine = true
-            };
-            HostInformationMessage link = new HostInformationMessage()
-            {
-                Message = ansiCodePrefix + "'Open-AzSurveyLink'"+ ansiCodeSuffix,
-                NoNewLine = true,
-            };
-            HostInformationMessage action = new HostInformationMessage()
-            {
-                Message = ansiCodePrefix + " to open in browser. Learn more at "+ ansiCodeSuffix,
-                NoNewLine = true,
-
-            };
-            HostInformationMessage website = new HostInformationMessage()
-            {
-                Message = ansiCodePrefix + "https://go.microsoft.com/fwlink/?linkid=2202892"+ ansiCodeSuffix,
-                NoNewLine = true,
-            };
-            WriteInformation(newLine, new string[] { "PSHOST" });
-            WriteInformation(howWas, new string[] { "PSHOST" });
-            WriteInformation(link, new string[] { "PSHOST" });
-            WriteInformation(action, new string[] { "PSHOST" });
-            WriteInformation(website, new string[] { "PSHOST" });
-            WriteInformation(newLine, new string[] { "PSHOST" });
-
-
+            var newLine = "\n";
+            var howWas = "[Survey] Help us improve Azure PowerShell by sharing your experience. This survey should take about 5 minutes. Run ";
+            var link = "'Open-AzSurveyLink'";
+            var action = " to open in browser. Learn more at ";
+            var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
+            WriteInformationWithAnsicodeStyle(newLine);
+            WriteInformationWithAnsicodeStyle(howWas, true);
+            WriteInformationWithAnsicodeStyle(link, true);
+            WriteInformationWithAnsicodeStyle(action, true);
+            WriteInformationWithAnsicodeStyle(website, true);
+            WriteInformationWithAnsicodeStyle(newLine, true);
         }
         protected new void WriteError(ErrorRecord errorRecord)
         {
@@ -557,11 +535,10 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             base.WriteInformation(messageData, tags);
         }
 
-        protected void WriteInformation(string text)
+        protected void WriteInformationWithAnsicodeStyle(string text, bool? noNewLine = null)
         {
-            FlushDebugMessages();
-            HostInformationMessage message = new HostInformationMessage { Message = ansiCodePrefix + text + ansiCodeSuffix, NoNewLine = false };
-            base.WriteInformation(message, new string[1] {"PSHOST"});
+            HostInformationMessage message = new HostInformationMessage { Message = ansiCodePrefix + text + ansiCodeSuffix, NoNewLine = noNewLine };
+            WriteInformation(message, new string[1] { "PSHOST" });
         }
 
         protected new void WriteCommandDetail(string text)
@@ -610,7 +587,9 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
         {
             if (CommandRuntime != null)
             {
-                WriteInformation(string.Format("{0:T} - {1}", DateTime.Now, message));
+                WriteInformation(
+                    new HostInformationMessage { Message = string.Format("{0:T} - {1}", DateTime.Now, message), NoNewLine = false },
+                    new string[1] { "PSHOST" });
             }
         }
 

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -464,8 +464,8 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             // using '[k' for erase in line. '[0m' to ending ansi code
             string ansiCodeSuffix = "\u001b[K\u001b[0m";
             var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
-            WriteStringAsInformation(Environment.NewLine);
-            WriteStringAsInformation(ansiCodePrefix+string.Format(Resources.SurveyPreface, website)+ ansiCodeSuffix, false);
+            WriteStringInformation(Environment.NewLine);
+            WriteStringInformation(ansiCodePrefix+string.Format(Resources.SurveyPreface, website)+ ansiCodeSuffix, false);
         }
 
         protected new void WriteError(ErrorRecord errorRecord)
@@ -528,7 +528,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             base.WriteInformation(messageData, tags);
         }
 
-        protected void WriteStringAsInformation(string text, bool? noNewLine = null)
+        protected void WriteStringInformation(string text, bool? noNewLine = null)
         {
             HostInformationMessage message = new HostInformationMessage { Message = text, NoNewLine = noNewLine, BackgroundColor = ConsoleColor.Blue, ForegroundColor = ConsoleColor.White };
             WriteInformation(message, new string[1] { "PSHOST" });

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -20,6 +20,7 @@ using Microsoft.Azure.PowerShell.Common.UpgradeNotification;
 using Microsoft.Azure.ServiceManagement.Common.Models;
 using Microsoft.WindowsAzure.Commands.Common;
 using Microsoft.WindowsAzure.Commands.Common.CustomAttributes;
+using Microsoft.WindowsAzure.Commands.Common.Properties;
 using Microsoft.WindowsAzure.Commands.Common.Utilities;
 using System;
 using System.Collections.Concurrent;
@@ -457,17 +458,9 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 
         protected void WriteSurvey()
         {
-            var newLine = "\n";
-            var howWas = "[Survey] Help us improve Azure PowerShell by sharing your experience. This survey should take about 5 minutes. Run ";
-            var link = "'Open-AzSurveyLink'";
-            var action = " to open in browser. Learn more at ";
             var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
-            WriteHighlightedInformation(newLine);
-            WriteHighlightedInformation(howWas, true);
-            WriteHighlightedInformation(link, true);
-            WriteHighlightedInformation(action, true);
-            WriteHighlightedInformation(website, true);
-            WriteHighlightedInformation(newLine);
+            WriteHighlightedInformation(Environment.NewLine);
+            WriteHighlightedInformation(string.Format(Resources.SurveyPreface, website), false);
         }
 
         protected new void WriteError(ErrorRecord errorRecord)

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -468,13 +468,14 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             var link = "'Open-AzSurveyLink'";
             var action = " to open in browser. Learn more at ";
             var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
-            WriteInformationWithAnsicodeStyle(newLine);
-            WriteInformationWithAnsicodeStyle(howWas, true);
-            WriteInformationWithAnsicodeStyle(link, true);
-            WriteInformationWithAnsicodeStyle(action, true);
-            WriteInformationWithAnsicodeStyle(website, true);
-            WriteInformationWithAnsicodeStyle(newLine);
+            WriteInformationWithAnsiCodeStyle(newLine);
+            WriteInformationWithAnsiCodeStyle(howWas, true);
+            WriteInformationWithAnsiCodeStyle(link, true);
+            WriteInformationWithAnsiCodeStyle(action, true);
+            WriteInformationWithAnsiCodeStyle(website, true);
+            WriteInformationWithAnsiCodeStyle(newLine);
         }
+
         protected new void WriteError(ErrorRecord errorRecord)
         {
             FlushDebugMessages();
@@ -535,7 +536,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             base.WriteInformation(messageData, tags);
         }
 
-        protected void WriteInformationWithAnsicodeStyle(string text, bool? noNewLine = null)
+        protected void WriteInformationWithAnsiCodeStyle(string text, bool? noNewLine = null)
         {
             HostInformationMessage message = new HostInformationMessage { Message = ansiCodePrefix + text + ansiCodeSuffix, NoNewLine = noNewLine };
             WriteInformation(message, new string[1] { "PSHOST" });

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -465,7 +465,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             string ansiCodeSuffix = "\u001b[K\u001b[0m";
             var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
             WriteStringInformation(Environment.NewLine);
-            WriteStringInformation(ansiCodePrefix+string.Format(Resources.SurveyPreface, website)+ ansiCodeSuffix, false);
+            WriteStringInformation(ansiCodePrefix + string.Format(Resources.SurveyPreface, website) + ansiCodeSuffix, false);
         }
 
         protected new void WriteError(ErrorRecord errorRecord)
@@ -530,7 +530,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 
         protected void WriteStringInformation(string text, bool? noNewLine = null)
         {
-            HostInformationMessage message = new HostInformationMessage { Message = text, NoNewLine = noNewLine, BackgroundColor = ConsoleColor.Blue, ForegroundColor = ConsoleColor.White };
+            HostInformationMessage message = new HostInformationMessage { Message = text, NoNewLine = noNewLine };
             WriteInformation(message, new string[1] { "PSHOST" });
         }
 

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -464,8 +464,8 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             // using '[k' for erase in line. '[0m' to ending ansi code
             string ansiCodeSuffix = "\u001b[K\u001b[0m";
             var website = "https://go.microsoft.com/fwlink/?linkid=2202892";
-            WriteInformationToPsHost(Environment.NewLine);
-            WriteInformationToPsHost(ansiCodePrefix + string.Format(Resources.SurveyPreface, website) + ansiCodeSuffix, false);
+            WriteInformation(Environment.NewLine);
+            WriteInformation(ansiCodePrefix + string.Format(Resources.SurveyPreface, website) + ansiCodeSuffix, false);
         }
 
         protected new void WriteError(ErrorRecord errorRecord)

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -473,7 +473,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             WriteInformationWithAnsicodeStyle(link, true);
             WriteInformationWithAnsicodeStyle(action, true);
             WriteInformationWithAnsicodeStyle(website, true);
-            WriteInformationWithAnsicodeStyle(newLine, true);
+            WriteInformationWithAnsicodeStyle(newLine);
         }
         protected new void WriteError(ErrorRecord errorRecord)
         {

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -528,7 +528,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             base.WriteInformation(messageData, tags);
         }
 
-        protected void WriteInformationToPsHost(string text, bool? noNewLine = null)
+        protected void WriteInformation(string text, bool? noNewLine = null)
         {
             HostInformationMessage message = new HostInformationMessage { Message = text, NoNewLine = noNewLine };
             WriteInformation(message, new string[1] { "PSHOST" });

--- a/src/Common/ColorAndFormat/PSStyle.cs
+++ b/src/Common/ColorAndFormat/PSStyle.cs
@@ -1,0 +1,41 @@
+﻿namespace Microsoft.WindowsAzure.Commands.Common
+{
+    /// <summary>
+    /// Contains configuration for how PowerShell renders text.
+    /// </summary>
+    public sealed class PSStyle
+    {
+        /// <summary>
+        /// Contains background colors.
+        /// </summary>
+        public sealed class BackgroundColor
+        {
+            /// <summary>
+            /// Gets the color blue.
+            /// </summary>
+            public static string Blue { get; } = "\x1b[44m";
+        }
+
+        public static string Reset { get; } = "\x1b[0m";
+
+        /// <summary>
+        /// Gets value to turn off underlined.
+        /// </summary>
+        public static string UnderlineOff { get; } = "\x1b[24m";
+
+        /// <summary>
+        /// Gets value to turn on underlined.
+        /// </summary>
+        public static string Underline { get; } = "\x1b[4m";
+
+        /// <summary>
+        /// Gets value to turn off bold.
+        /// </summary>
+        public static string BoldOff { get; } = "\x1b[22m";
+
+        /// <summary>
+        /// Gets value to turn on bold.
+        /// </summary>
+        public static string Bold { get; } = "\x1b[1m";
+    }
+}

--- a/src/Common/ColorAndFormat/PSStyle.cs
+++ b/src/Common/ColorAndFormat/PSStyle.cs
@@ -2,6 +2,7 @@
 {
     /// <summary>
     /// Contains configuration for how PowerShell renders text.
+    /// A subset of https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
     /// </summary>
     public sealed class PSStyle
     {

--- a/src/Common/ColorAndFormat/PSStyle.cs
+++ b/src/Common/ColorAndFormat/PSStyle.cs
@@ -1,8 +1,22 @@
-﻿namespace Microsoft.WindowsAzure.Commands.Common
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+namespace Microsoft.WindowsAzure.Commands.Common
 {
     /// <summary>
     /// Contains configuration for how PowerShell renders text.
-    /// A subset of https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs
+    /// A subset of https://github.com/PowerShell/PowerShell/blob/f0076b9d883aa0ed07fb2a5c2be5f38f5d945e1e/src/System.Management.Automation/FormatAndOutput/common/PSStyle.cs#L173
     /// </summary>
     public sealed class PSStyle
     {

--- a/src/Common/Properties/Resources.Designer.cs
+++ b/src/Common/Properties/Resources.Designer.cs
@@ -4287,6 +4287,15 @@ namespace Microsoft.WindowsAzure.Commands.Common.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to [Survey] Help us improve Azure PowerShell by sharing your experience. This survey should take about 5 minutes. Run &apos;Open-AzSurveyLink&apos; to open in browser. Learn more at {0}.
+        /// </summary>
+        public static string SurveyPreface {
+            get {
+                return ResourceManager.GetString("SurveyPreface", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Suspend.
         /// </summary>
         public static string Suspend {

--- a/src/Common/Properties/Resources.resx
+++ b/src/Common/Properties/Resources.resx
@@ -1757,4 +1757,7 @@ Note : Go to {0} for steps to suppress this breaking change warning, and other i
     <value>
 - The change is expected to take effect in {0} version : '{1}'</value>
   </data>
+  <data name="SurveyPreface" xml:space="preserve">
+    <value>[Survey] Help us improve Azure PowerShell by sharing your experience. This survey should take about 5 minutes. Run 'Open-AzSurveyLink' to open in browser. Learn more at {0}</value>
+  </data>
 </root>

--- a/src/Dependencies.targets
+++ b/src/Dependencies.targets
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>    
+    <!-- Suppress known NuGet package vulnerabilities to unblock build as we track this kind of security issues internally. -->
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup Condition="'$(OmitJsonPackage)' != 'true'">
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
         public const string WriteDebugKey = "WriteDebug";
         public const string WriteVerboseKey = "WriteVerbose";
         public const string WriteWarningKey = "WriteWarning";
+        public const string WriteInformationKey = "WriteInformation";
         public const string EnqueueDebugKey = "EnqueueDebug";
         private const string SubscriptionIdParameter = "SubscriptionId";
 
@@ -214,7 +215,6 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
 
             return subscriptionObjects;
         }
-
 
         private IAccessToken GetTokenForTenant(string tenantId)
         {
@@ -572,6 +572,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
         private event EventHandler<StreamEventArgs> _writeDebugEvent;
         private event EventHandler<StreamEventArgs> _writeVerboseEvent;
         private event EventHandler<StreamEventArgs> _writeWarningEvent;
+        private event EventHandler<StreamEventArgs> _writeInformationEvent;
         private event EventHandler<StreamEventArgs> _enqueueDebugEvent;
 
         private void InitializeEventHandlers()
@@ -582,11 +583,14 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
             _writeVerboseEvent += WriteVerboseSender;
             _writeWarningEvent -= WriteWarningSender;
             _writeWarningEvent += WriteWarningSender;
+            _writeInformationEvent -= WriteInformationSender;
+            _writeInformationEvent += WriteInformationSender;
             _enqueueDebugEvent -= EnqueueDebugSender;
             _enqueueDebugEvent += EnqueueDebugSender;
             AzureSession.Instance.RegisterComponent(WriteDebugKey, () => _writeDebugEvent, true);
             AzureSession.Instance.RegisterComponent(WriteVerboseKey, () => _writeVerboseEvent, true);
             AzureSession.Instance.RegisterComponent(WriteWarningKey, () => _writeWarningEvent, true);
+            AzureSession.Instance.RegisterComponent(WriteInformationKey, () => _writeInformationEvent, true);
             AzureSession.Instance.RegisterComponent(EnqueueDebugKey, () => _enqueueDebugEvent, true);
         }
 
@@ -603,6 +607,11 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
         private void WriteWarningSender(object sender, StreamEventArgs args)
         {
             WriteWarningWithTimestamp(args.Message);
+        }
+
+        private void WriteInformationSender(object sender, StreamEventArgs args)
+        {
+            WriteInformationWithTimestamp(args.Message);
         }
 
         private void EnqueueDebugSender(object sender, StreamEventArgs args)


### PR DESCRIPTION
- Added method to write information and write string information.
- Predefined ansi color and format used in device code login message.
![image](https://github.com/Azure/azure-powershell-common/assets/19869716/a5025c70-cdcb-4fe3-91bf-79a04381e537)
