### PR TITLE
Enable TenantId to Retrieve Auxiliary Auth Header

### DIFF
--- a/src/ResourceManager.Test/AzureRMCmdletAuthenticationUnitTests.cs
+++ b/src/ResourceManager.Test/AzureRMCmdletAuthenticationUnitTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Test
 
         public class MockCmdlet : AzureRMCmdlet
         {
-            public IDictionary<string, List<string>> GetAuxilaryAuthHeaderByTenatIds(IEnumerable<string> tenantIds)
+            public IDictionary<string, IList<string>> GetAuxilaryAuthHeaderByTenatIds(IEnumerable<string> tenantIds)
             {
                 return base.GetAuxiliaryAuthHeaderFromTenantIds(tenantIds);
             }

--- a/src/ResourceManager.Test/AzureRMCmdletAuthenticationUnitTests.cs
+++ b/src/ResourceManager.Test/AzureRMCmdletAuthenticationUnitTests.cs
@@ -1,0 +1,159 @@
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.Common.Authentication;
+using Microsoft.Azure.Commands.Common.Authentication.Abstractions;
+using Microsoft.Azure.Commands.Common.Authentication.Abstractions.Core;
+using Microsoft.Azure.Commands.ResourceManager.Common;
+
+using Moq;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security;
+using System.Text.RegularExpressions;
+
+using Xunit;
+
+namespace Microsoft.Azure.Commands.ResourceManager.Test
+{
+    public class AzureRMCmdletAuthenticationUnitTests
+    {
+
+        private static readonly AzureAccount azureAccount = new AzureAccount()
+        {
+            Id = "fakeUserId",
+            Type = AzureAccount.AccountType.User
+        };
+
+        private static IAzureSession CreateAuthenticationFactory()
+        {
+            var session = new Mock<IAzureSession>();
+            var authFactory = new Mock<IAuthenticationFactory>();
+            authFactory.Setup(f => f.Authenticate(
+                It.IsAny<IAzureAccount>(),
+                It.IsAny<IAzureEnvironment>(),
+                It.IsAny<string>(),
+                It.IsAny<SecureString>(),
+                It.IsAny<string>(),
+                It.IsAny<Action<string>>(),
+                It.IsAny<string>())).Returns<IAzureAccount, IAzureEnvironment, string, SecureString, string, Action<string>, string>
+                ((a, e, t, w, b, p, r) => new MockAccessToken(azureAccount.Id, t, azureAccount.Type, t));
+            session.SetupProperty(m => m.AuthenticationFactory, authFactory.Object);
+            return session.Object;
+        }
+
+        private static AzureRmProfileProvider CreateAzureRmProfile()
+        {
+            var context = new Mock<IAzureContext>();
+            context.SetupProperty(m => m.Account, azureAccount);
+
+            var profile = new Mock<IAzureContextContainer>();
+            profile.SetupProperty(m => m.DefaultContext, context.Object);
+
+            var profileProvider = new Mock<AzureRmProfileProvider>();
+            profileProvider.SetupProperty(m => m.Profile, profile.Object);
+            return profileProvider.Object;
+        }
+
+        private static void InitializeSessionAndProfile()
+        {
+            AzureSession.Initialize(CreateAuthenticationFactory, true);
+            AzureSession.Modify(s => s.ARMContextSaveMode = ContextSaveMode.Process);
+            AzureRmProfileProvider.SetInstance(() => CreateAzureRmProfile(), true);
+        }
+
+        private static void Dispose()
+        {
+            AzureRmProfileProvider.SetInstance(() => null, true);
+            AzureSession.Modify(s => s = null);
+        }
+
+        public class MockCmdlet : AzureRMCmdlet
+        {
+            public IDictionary<string, List<string>> GetAuxilaryAuthHeaderByTenatIds(IEnumerable<string> tenantIds)
+            {
+                return base.GetAuxiliaryAuthHeaderFromTenantIds(tenantIds);
+            }
+
+        }
+
+        [Fact]
+        public void TestGetAuxHeaderByTenantIds()
+        {
+            try
+            {
+                InitializeSessionAndProfile();
+                var cmdlet = new MockCmdlet();
+                var tenants = new List<string>() { "tenant0", "tenant1", "tenant2" };
+
+                var header = cmdlet.GetAuxilaryAuthHeaderByTenatIds(tenants);
+
+                Assert.Equal(1, header.Count);
+                var h = header.First();
+                Assert.Equal("x-ms-authorization-auxiliary", h.Key);
+                Assert.Single(h.Value);
+                var tokens = h.Value.First().Split(';');
+                var regex = new Regex(@"Bearer ([0-9a-zA-Z]+)");
+                for (int i = 0; i < tenants.Count; ++i)
+                {
+                    var match = regex.Match(tokens[i]);
+                    Assert.True(match.Success);
+                    match.Groups[1].Value.StartsWith(tenants[i]);
+                }
+            }
+            finally
+            {
+                Dispose();
+            }
+        }
+
+        [Fact]
+        public void TestGetAuxHeaderByEmptyTenantIds()
+        {
+            try
+            {
+                InitializeSessionAndProfile();
+                var cmdlet = new MockCmdlet();
+                var tenants = new List<string>();
+
+                var header = cmdlet.GetAuxilaryAuthHeaderByTenatIds(tenants);
+
+                Assert.Null(header);
+            }
+            finally
+            {
+                Dispose();
+            }
+        }
+
+        [Fact]
+        public void TestGetAuxHeaderByExcessTenantIds()
+        {
+            try
+            {
+                InitializeSessionAndProfile();
+                var cmdlet = new MockCmdlet();
+                var tenants = new List<string>() { "tenant0", "tenant1", "tenant2", "tenants3" };
+
+                Assert.Throws<ArgumentException>(() => cmdlet.GetAuxilaryAuthHeaderByTenatIds(tenants));
+            }
+            finally
+            {
+                Dispose();
+            }
+        }
+    }
+}

--- a/src/ResourceManager.Test/MockAccessToken.cs
+++ b/src/ResourceManager.Test/MockAccessToken.cs
@@ -1,0 +1,56 @@
+﻿// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.Azure.Commands.Common.Authentication;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Commands.ResourceManager.Test
+{
+    public class MockAccessToken : IRenewableToken
+    {
+        public string TenantId { get; set; }
+
+        public string UserId { get; set; }
+
+        public string LoginType { get; set; }
+
+        public string AccessToken { get; set; }
+
+        public DateTimeOffset ExpiresOn { get; set; }
+
+        public MockAccessToken() { }
+
+        public MockAccessToken(string userId, string tenantId, string loginType, string tokenStartWith)
+        {
+            UserId = userId;
+            HomeAccountId = "fakeAccountId";
+            var current = DateTime.UtcNow;
+            AccessToken = tokenStartWith + Convert.ToBase64String(BitConverter.GetBytes(current.Ticks));
+            ExpiresOn = current.AddYears(1);
+
+            TenantId = tenantId;
+            LoginType = loginType;
+        }
+
+        public void AuthorizeRequest(Action<string, string> authTokenSetter)
+        {
+            authTokenSetter("Bearer", AccessToken);
+        }
+
+        public string HomeAccountId { get; set; }
+
+        public IDictionary<string, string> ExtendedProperties => throw new NotImplementedException();
+    }
+}

--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
                 // WE can only fill in tokens for 3 tennats in the aux header, if tehre are more tenants fail now
                 if (tenantIds.Count() > MAX_NUMBER_OF_TOKENS_ALLOWED_IN_AUX_HEADER)
                 {
-                    throw new ArgumentException("Number of tenants (tenants other than the one in the current context), that the requested resources belongs to, exceeds maximum allowed number of " + MAX_NUMBER_OF_TOKENS_ALLOWED_IN_AUX_HEADER);
+                    throw new ArgumentException("Number of tenants (tenants other than the one in the current context), that the requested resources belong to, exceeds maximum allowed number of " + MAX_NUMBER_OF_TOKENS_ALLOWED_IN_AUX_HEADER);
                 }
 
                 //get the tokens for each tenant and prepare the string in the following format :

--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -160,7 +160,9 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
                 //get the tokens for each tenant and prepare the string in the following format :
                 //"Header Value :: Bearer <auxiliary token1>;EncryptedBearer <auxiliary token2>; Bearer <auxiliary token3>"
 
-                var tokens = tenantIds.Select(t => (new StringBuilder(AUX_TOKEN_PREFIX).Append(" ").Append(GetTokenForTenant(t)?.AccessToken))?.ToString())?.ConcatStrings(AUX_TOKEN_APPEND_CHAR);
+var tokens = tenantIds
+    .Select(t => $"{AUX_TOKEN_PREFIX} {GetTokenForTenant(t)?.AccessToken}")
+    .ConcatStrings(AUX_TOKEN_APPEND_CHAR);
 
                 var auxHeader = new Dictionary<String, List<String>>();
 


### PR DESCRIPTION
This pull request includes changes to add new unit tests and methods related to authentication functionality. The most important changes include adding a new unit test class `AzureRMCmdletAuthenticationUnitTests` with test methods for the `GetAuxilaryAuthHeaderByTenatIds` method, and adding a new method `GetAuxiliaryAuthHeaderFromTenantIds` to the `AzureRMCmdlet` class for generating authentication headers.

Authentication improvements:

* [`src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs`](diffhunk://#diff-4fc6524a8cc5579c0ba48a332feff18740fd36a7976cf50ff058859f316044b2R150-R174): Added a new method `GetAuxiliaryAuthHeaderFromTenantIds` to the `AzureRMCmdlet` class for generating authentication headers for a list of tenant IDs.

Testing improvements:

* [`src/ResourceManager.Test/AzureRMCmdletAuthenticationUnitTests.cs`](diffhunk://#diff-7612c52daee7f43404df8e6977910156cc47a998893972bc5702d6c5968308cbR1-R159): Added a new unit test class `AzureRMCmdletAuthenticationUnitTests` with test methods to test the functionality of the `GetAuxilaryAuthHeaderByTenatIds` method.