### PR TITLE
Add sanitize duration in the debug message and removed in EndProcessing

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -413,7 +413,6 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                     {
                         WriteWarning(string.Format(Resources.DisplaySecretsWarningMessage, MyInvocation.InvocationName, string.Join(", ", sanitizerInfo.DetectedProperties)));
                     }
-                    WriteDebug($"Sanitizer took {sanitizerInfo.SanitizeDuration.TotalMilliseconds}ms to process the object of cmdlet {MyInvocation.InvocationName}.");
                 }
             }
         }

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -690,21 +690,26 @@ public class AzurePSQoSEvent
         StringBuilder sb = new StringBuilder("AzureQoSEvent: ");
         if (ShowTelemetry)
         {
-            foreach(PropertyDescriptor descriptor in TypeDescriptor.GetProperties((this)))
-                {
-                    string name = descriptor.Name;
-                    object value = descriptor.GetValue(this);
-                    sb.Append($"{name}: {value}; ");
-                }
+            foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties((this)))
+            {
+                string name = descriptor.Name;
+                object value = descriptor.GetValue(this);
+                sb.Append($"{name}: {value}; ");
+            }
             //InstallationId and InternalCalledCmdlets are properties of MetricHelper and  not in qosEventObject.
             sb.Append($"InternalCalledCmdlets: {Microsoft.WindowsAzure.Commands.Common.MetricHelper.InternalCalledCmdlets}; InstallaionId: {Microsoft.WindowsAzure.Commands.Common.MetricHelper.InstallationId}");
         }
         else
         {
-            sb = sb.Append($" Module: {ModuleName}:{ModuleVersion}; CommandName: {CommandName}; PSVersion: {PSVersion}");
+            sb.Append($" Module: {ModuleName}:{ModuleVersion}; CommandName: {CommandName}; PSVersion: {PSVersion}");
         }
 
         sb.Append($"; IsSuccess: {IsSuccess}; Duration: {Duration}");
+
+        if (SanitizerInfo?.ShowSecretsWarning == true)
+        {
+            sb.Append($"; SanitizeDuration: {SanitizerInfo.SanitizeDuration}");
+        }
 
         if (Exception != null)
         {


### PR DESCRIPTION
This pull request includes changes in two files: `src/Common/AzurePSCmdlet.cs` and `src/Common/MetricHelper.cs`. The changes revolve around the handling and logging of sanitizer information. The debug log about the sanitizing process duration has been removed from `AzurePSCmdlet.cs`. In `MetricHelper.cs`, the `ToString()` method has been updated to include the sanitizing duration in the output string if the `ShowSecretsWarning` property is set to `true`.

* [`src/Common/AzurePSCmdlet.cs`]: Removed the debug log line that displayed the time taken by the sanitizer to process the object of the cmdlet. This change simplifies the output and removes potentially unnecessary information.

* [`src/Common/MetricHelper.cs`]: Updated the `ToString()` method to include the sanitizing duration in the output string if the `ShowSecretsWarning` property is `true`. This change provides more detailed information about the sanitizing process when it's relevant.