### PR TITLE
opt-in error record config

### DIFF
--- a/src/Authentication.Abstractions/Models/ConfigKeysForCommon.cs
+++ b/src/Authentication.Abstractions/Models/ConfigKeysForCommon.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Azure.PowerShell.Common.Config
         public const string EnableDataCollection = "EnableDataCollection";
         public const string EnableTestCoverage = "EnableTestCoverage";
         public const string CheckForUpgrade = "CheckForUpgrade";
-        //Use DisableErrorRecordsPersistence as opt-out for now, will replace it with EnableErrorRecordsPersistence as opt-in at next major release (November 2023)
-        public const string DisableErrorRecordsPersistence = "DisableErrorRecordsPersistence";
         public const string EnableErrorRecordsPersistence = "EnableErrorRecordsPersistence";
         public const string DisplaySecretsWarning = "DisplaySecretsWarning";
     }

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -819,8 +819,8 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
         //Use DisableErrorRecordsPersistence as opt-out for now, will replace it with EnableErrorRecordsPersistence as opt-in at next major release (November 2023)
         private bool ShouldRecordDebugMessages()
         {
-            return (!AzureSession.Instance.TryGetComponent<IConfigManager>(nameof(IConfigManager), out var configManager)
-                || !configManager.GetConfigValue<bool>(ConfigKeysForCommon.DisableErrorRecordsPersistence))
+            return AzureSession.Instance.TryGetComponent<IConfigManager>(nameof(IConfigManager), out var configManager)
+                && configManager.GetConfigValue<bool>(ConfigKeysForCommon.EnableErrorRecordsPersistence)
                 && IsDataCollectionAllowed();
         }
 


### PR DESCRIPTION
This pull request primarily focuses on the transition from using `DisableErrorRecordsPersistence` to `EnableErrorRecordsPersistence` in the `ConfigKeysForCommon` class and the `ShouldRecordDebugMessages` method. The changes are made to improve the code's readability and to make the feature opt-in rather than opt-out.

Key changes include:

* [`src/Authentication.Abstractions/Models/ConfigKeysForCommon.cs`](diffhunk://#diff-a0d7472a155c7177d7e58df9cd48b0f8613c6837e66ad5a6eed1b13f0a00dca0L32-L33): Removed the `DisableErrorRecordsPersistence` constant from the `ConfigKeysForCommon` class. The `EnableErrorRecordsPersistence` constant is now being used instead. This change is made to switch from an opt-out to an opt-in system for error record persistence.
  
* [`src/Common/AzurePSCmdlet.cs`](diffhunk://#diff-f502b3fb26d4e039f1601ef76310ed87b79ca228f407f9104d757acc71397f2aL826-R827): Modified the `ShouldRecordDebugMessages` method to use the `EnableErrorRecordsPersistence` constant instead of the `DisableErrorRecordsPersistence` constant. This change aligns with the modification in `ConfigKeysForCommon` and ensures consistency across the codebase.