### PR TITLE
Change ConfigMetrics from Array to Dictionary

### DIFF
--- a/src/Authentication.Abstractions/Models/ConfigMetrics.cs
+++ b/src/Authentication.Abstractions/Models/ConfigMetrics.cs
@@ -29,16 +29,24 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions.Models
         public string ConfigKey { get; private set; }
 
         /// <summary>
+        /// The unique telemetry key of config. It's required for recording config telemetry. If not provided, it's same with ConfigKey.
+        /// </summary>
+        public string TelemetryKey { get; private set; }
+
+        /// <summary>
         /// Config value in string format. It's required for recording config telemetry.
         /// </summary>
         public string ConfigValue { get; private set; }
 
         public IDictionary<string, string> ExtendedProperties { get; } = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        public ConfigMetrics(string ConfigKey, string ConfigValue)
+        public ConfigMetrics(string configKey, string configValue): this(configKey, configKey, configValue){}
+
+        public ConfigMetrics(string configKey, string telemetryKey, string configValue)
         {
-            this.ConfigKey = ConfigKey;
-            this.ConfigValue = ConfigValue;
+            this.ConfigKey = configKey;
+            this.TelemetryKey = telemetryKey;
+            this.ConfigValue = configValue;
         }
     }
 }

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -508,7 +508,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 foreach (var configMetric in qos.ConfigMetrics)
                 {
-                    eventProperties[configMetric.ConfigKey] = configMetric.ConfigValue;
+                    eventProperties[configMetric.Value.ConfigKey] = configMetric.Value.ConfigValue;
                 }
             }
         }
@@ -670,7 +670,7 @@ public class AzurePSQoSEvent
     public string ParameterSetName { get; set; }
     public string InvocationName { get; set; }
 
-    public List<ConfigMetrics> ConfigMetrics { get; private set; } 
+    public Dictionary<string, ConfigMetrics> ConfigMetrics { get; private set; } 
 
     public Dictionary<string, string> CustomProperties { get; private set; }
 
@@ -683,7 +683,7 @@ public class AzurePSQoSEvent
         StartTime = DateTimeOffset.Now;
         _timer = new Stopwatch();
         _timer.Start();
-        ConfigMetrics = new List<ConfigMetrics>();
+        ConfigMetrics = new Dictionary<string, ConfigMetrics>();
         CustomProperties = new Dictionary<string, string>();
     }
 

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -508,7 +508,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 foreach (var configMetric in qos.ConfigMetrics)
                 {
-                    eventProperties[configMetric.Value.ConfigKey] = configMetric.Value.ConfigValue;
+                    eventProperties[configMetric.Value.TelemetryKey] = configMetric.Value.ConfigValue;
                 }
             }
         }


### PR DESCRIPTION
Change ConfigMetrics from Array to Dictionary, two benefits:

- We could check if this config is added in o(1) complexity. Previous design is o(n). A config could be read many times. In worst cases, List<ConfigMetrics> ConfigMetrics may contain same config info and exceed space limit
- We can define nickname for config. Take LoginExperienceV2 for instance, we can add 
ConfigMetrics.Add(ConfigKeys.LoginExperienceV2, new ConfigMetrics(ConfigKeys.LoginExperienceV2, "LoginExperienceVTwo", "On")) for telemetry as our database can't recognize number value in telemetry field.
![image](https://github.com/Azure/azure-powershell-common/assets/19869716/0014b4df-eb4f-4a9a-9502-781cbb5936eb)


-- no breaking change is introduced as ConfigMetrics is never used yey.