### PR TITLE
Add new properties in the IOutputSanitizer

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -548,7 +548,9 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 
         private void SanitizeOutput(object sendToPipeline)
         {
-            if (OutputSanitizer?.RequireSecretsDetection == true)
+            if (OutputSanitizer != null && OutputSanitizer.RequireSecretsDetection
+                && !OutputSanitizer.IgnoredModules.Contains(MyInvocation?.MyCommand?.ModuleName)
+                && !OutputSanitizer.IgnoredCmdlets.Contains(MyInvocation?.MyCommand?.Name))
             {
                 OutputSanitizer.Sanitize(sendToPipeline, out var telemetry);
                 _qosEvent?.SanitizerInfo.Combine(telemetry);

--- a/src/Common/Sanitizer/IOutputSanitizer.cs
+++ b/src/Common/Sanitizer/IOutputSanitizer.cs
@@ -12,11 +12,17 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Microsoft.WindowsAzure.Commands.Common.Sanitizer
 {
     public interface IOutputSanitizer
     {
         bool RequireSecretsDetection { get; }
+
+        IEnumerable<string> IgnoredModules { get; }
+
+        IEnumerable<string> IgnoredCmdlets { get; }
 
         void Sanitize(object sanitizingObject, out SanitizerTelemetry telemetryData);
     }


### PR DESCRIPTION
Add IgnoredModules and IgnoredCmdlets to bypass unnecessary modules and/or cmdlets for secrets detection.