### PR TITLE
Remove PSStyle if terminal does not support escape sequence

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -334,11 +334,21 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             AzureSession.Instance.ClientFactory.RemoveUserAgent(ModuleName);
             AzureSession.Instance.ClientFactory.RemoveHandler(typeof(CmdletInfoHandler));
         }
+
+        protected virtual void InitializePSStyle()
+        {
+            if (null == PSStyle.SupportsVirtualTerminal)
+            {
+                PSStyle.SupportsVirtualTerminal = Host.UI.SupportsVirtualTerminal;
+            }
+        }
+
         /// <summary>
         /// Cmdlet begin process. Write to logs, setup Http Tracing and initialize profile
         /// </summary>
         protected override void BeginProcessing()
         {
+            InitializePSStyle();
             FlushInitializationWarnings();
             SessionState = base.SessionState;
             var profile = _dataCollectionProfile;

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -335,20 +335,11 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             AzureSession.Instance.ClientFactory.RemoveHandler(typeof(CmdletInfoHandler));
         }
 
-        protected virtual void InitializePSStyle()
-        {
-            if (null == PSStyle.SupportsVirtualTerminal)
-            {
-                PSStyle.SupportsVirtualTerminal = Host.UI.SupportsVirtualTerminal;
-            }
-        }
-
         /// <summary>
         /// Cmdlet begin process. Write to logs, setup Http Tracing and initialize profile
         /// </summary>
         protected override void BeginProcessing()
         {
-            InitializePSStyle();
             FlushInitializationWarnings();
             SessionState = base.SessionState;
             var profile = _dataCollectionProfile;

--- a/src/Common/ColorAndFormat/PSStyle.cs
+++ b/src/Common/ColorAndFormat/PSStyle.cs
@@ -12,6 +12,8 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------------
 
+using System.Management.Automation.Host;
+
 namespace Microsoft.WindowsAzure.Commands.Common
 {
     /// <summary>
@@ -20,7 +22,28 @@ namespace Microsoft.WindowsAzure.Commands.Common
     /// </summary>
     public sealed class PSStyle
     {
-        public static bool? SupportsVirtualTerminal = null;
+        private static bool? _isEscapeSequenceSupported = null;
+
+        public static bool IsEscapeSequenceSupported
+        {
+            get
+            {
+                if (_isEscapeSequenceSupported.HasValue)
+                {
+                    return _isEscapeSequenceSupported.Value;
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// This function should be invoked only in the Az.Accounts.
+        /// </summary>
+        /// <param name="host">PowerShell Console Host</param>
+        public static void Initialize(PSHost host)
+        {
+            _isEscapeSequenceSupported = host?.UI?.SupportsVirtualTerminal;
+        }
 
         /// <summary>
         /// Contains background colors.
@@ -34,7 +57,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[40m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[40m" : "";
                 }
             }
 
@@ -45,7 +68,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[41m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[41m" : "";
                 }
             }
 
@@ -56,7 +79,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[42m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[42m" : "";
                 }
             }
 
@@ -67,7 +90,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[43m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[43m" : "";
                 }
             }
 
@@ -78,7 +101,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[44m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[44m" : "";
                 }
             }
 
@@ -89,7 +112,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[45m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[45m" : "";
                 }
             }
 
@@ -100,7 +123,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[46m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[46m" : "";
                 }
             }
 
@@ -111,7 +134,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[47m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[47m" : "";
                 }
             }
 
@@ -122,7 +145,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[100m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[100m" : "";
                 }
             }
 
@@ -133,7 +156,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[101m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[101m" : "";
                 }
             }
 
@@ -144,7 +167,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[102m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[102m" : "";
                 }
             }
 
@@ -155,7 +178,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[103m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[103m" : "";
                 }
             }
 
@@ -166,7 +189,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[104m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[104m" : "";
                 }
             }
 
@@ -177,7 +200,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[105m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[105m" : "";
                 }
             }
 
@@ -188,7 +211,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[106m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[106m" : "";
                 }
             }
 
@@ -199,7 +222,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[107m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[107m" : "";
                 }
             }
         }
@@ -217,7 +240,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[30m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[30m" : "";
                 }
             }
 
@@ -228,7 +251,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[31m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[31m" : "";
                 }
             }
 
@@ -239,7 +262,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[32m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[32m" : "";
                 }
             }
 
@@ -250,7 +273,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[33m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[33m" : "";
                 }
             }
 
@@ -261,7 +284,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[34m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[34m" : "";
                 }
             }
 
@@ -272,7 +295,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[35m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[35m" : "";
                 }
             }
 
@@ -283,7 +306,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[36m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[36m" : "";
                 }
             }
 
@@ -294,7 +317,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[37m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[37m" : "";
                 }
             }
 
@@ -305,7 +328,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[90m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[90m" : "";
                 }
             }
 
@@ -316,7 +339,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[91m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[91m" : "";
                 }
             }
 
@@ -327,7 +350,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[92m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[92m" : "";
                 }
             }
 
@@ -338,7 +361,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[93m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[93m" : "";
                 }
             }
 
@@ -349,7 +372,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[94m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[94m" : "";
                 }
             }
 
@@ -360,7 +383,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[95m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[95m" : "";
                 }
             }
 
@@ -371,7 +394,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[96m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[96m" : "";
                 }
             }
 
@@ -382,7 +405,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return SupportsVirtualTerminal == true ? "\x1b[97m" : "";
+                    return IsEscapeSequenceSupported ? "\x1b[97m" : "";
                 }
             }
         }
@@ -391,7 +414,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return SupportsVirtualTerminal == true ? "\x1b[0m" : "";
+                return IsEscapeSequenceSupported ? "\x1b[0m" : "";
             }
         }
 
@@ -402,7 +425,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return SupportsVirtualTerminal == true ? "\x1b[24m" : "";
+                return IsEscapeSequenceSupported ? "\x1b[24m" : "";
             }
         }
 
@@ -413,7 +436,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return SupportsVirtualTerminal == true ? "\x1b[4m" : "";
+                return IsEscapeSequenceSupported ? "\x1b[4m" : "";
             }
         }
 
@@ -424,7 +447,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return SupportsVirtualTerminal == true ? "\x1b[22m" : "";
+                return IsEscapeSequenceSupported ? "\x1b[22m" : "";
             }
         }
 
@@ -435,7 +458,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return SupportsVirtualTerminal == true ? "\x1b[1m" : "";
+                return IsEscapeSequenceSupported ? "\x1b[1m" : "";
             }
         }
     }

--- a/src/Common/ColorAndFormat/PSStyle.cs
+++ b/src/Common/ColorAndFormat/PSStyle.cs
@@ -24,20 +24,9 @@ namespace Microsoft.WindowsAzure.Commands.Common
     {
         private static bool? _isEscapeSequenceSupported = null;
 
-        public static bool IsEscapeSequenceSupported
-        {
-            get
-            {
-                if (_isEscapeSequenceSupported.HasValue)
-                {
-                    return _isEscapeSequenceSupported.Value;
-                }
-                return false;
-            }
-        }
-
         /// <summary>
-        /// This function should be invoked only in the Az.Accounts.
+        /// Initializes default settings of PSStyle according to the environment.
+        /// Note: This function should be invoked only in Az.Accounts.
         /// </summary>
         /// <param name="host">PowerShell Console Host</param>
         public static void Initialize(PSHost host)
@@ -57,7 +46,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[40m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[40m" : "";
                 }
             }
 
@@ -68,7 +57,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[41m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[41m" : "";
                 }
             }
 
@@ -79,7 +68,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[42m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[42m" : "";
                 }
             }
 
@@ -90,7 +79,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[43m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[43m" : "";
                 }
             }
 
@@ -101,7 +90,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[44m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[44m" : "";
                 }
             }
 
@@ -112,7 +101,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[45m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[45m" : "";
                 }
             }
 
@@ -123,7 +112,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[46m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[46m" : "";
                 }
             }
 
@@ -134,7 +123,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[47m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[47m" : "";
                 }
             }
 
@@ -145,7 +134,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[100m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[100m" : "";
                 }
             }
 
@@ -156,7 +145,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[101m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[101m" : "";
                 }
             }
 
@@ -167,7 +156,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[102m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[102m" : "";
                 }
             }
 
@@ -178,7 +167,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[103m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[103m" : "";
                 }
             }
 
@@ -189,7 +178,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[104m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[104m" : "";
                 }
             }
 
@@ -200,7 +189,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[105m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[105m" : "";
                 }
             }
 
@@ -211,7 +200,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[106m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[106m" : "";
                 }
             }
 
@@ -222,7 +211,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[107m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[107m" : "";
                 }
             }
         }
@@ -240,7 +229,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[30m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[30m" : "";
                 }
             }
 
@@ -251,7 +240,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[31m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[31m" : "";
                 }
             }
 
@@ -262,7 +251,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[32m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[32m" : "";
                 }
             }
 
@@ -273,7 +262,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[33m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[33m" : "";
                 }
             }
 
@@ -284,7 +273,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[34m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[34m" : "";
                 }
             }
 
@@ -295,7 +284,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[35m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[35m" : "";
                 }
             }
 
@@ -306,7 +295,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[36m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[36m" : "";
                 }
             }
 
@@ -317,7 +306,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[37m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[37m" : "";
                 }
             }
 
@@ -328,7 +317,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[90m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[90m" : "";
                 }
             }
 
@@ -339,7 +328,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[91m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[91m" : "";
                 }
             }
 
@@ -350,7 +339,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[92m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[92m" : "";
                 }
             }
 
@@ -361,7 +350,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[93m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[93m" : "";
                 }
             }
 
@@ -372,7 +361,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[94m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[94m" : "";
                 }
             }
 
@@ -383,7 +372,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[95m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[95m" : "";
                 }
             }
 
@@ -394,7 +383,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[96m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[96m" : "";
                 }
             }
 
@@ -405,7 +394,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 get
                 {
-                    return IsEscapeSequenceSupported ? "\x1b[97m" : "";
+                    return _isEscapeSequenceSupported == true ? "\x1b[97m" : "";
                 }
             }
         }
@@ -414,7 +403,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return IsEscapeSequenceSupported ? "\x1b[0m" : "";
+                return _isEscapeSequenceSupported == true ? "\x1b[0m" : "";
             }
         }
 
@@ -425,7 +414,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return IsEscapeSequenceSupported ? "\x1b[24m" : "";
+                return _isEscapeSequenceSupported == true ? "\x1b[24m" : "";
             }
         }
 
@@ -436,7 +425,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return IsEscapeSequenceSupported ? "\x1b[4m" : "";
+                return _isEscapeSequenceSupported == true ? "\x1b[4m" : "";
             }
         }
 
@@ -447,7 +436,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return IsEscapeSequenceSupported ? "\x1b[22m" : "";
+                return _isEscapeSequenceSupported == true ? "\x1b[22m" : "";
             }
         }
 
@@ -458,7 +447,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             get
             {
-                return IsEscapeSequenceSupported ? "\x1b[1m" : "";
+                return _isEscapeSequenceSupported == true ? "\x1b[1m" : "";
             }
         }
     }

--- a/src/Common/ColorAndFormat/PSStyle.cs
+++ b/src/Common/ColorAndFormat/PSStyle.cs
@@ -20,6 +20,8 @@ namespace Microsoft.WindowsAzure.Commands.Common
     /// </summary>
     public sealed class PSStyle
     {
+        public static bool? SupportsVirtualTerminal = null;
+
         /// <summary>
         /// Contains background colors.
         /// </summary>
@@ -28,82 +30,178 @@ namespace Microsoft.WindowsAzure.Commands.Common
             /// <summary>
             /// Gets the color black.
             /// </summary>
-            public static string Black { get; } = "\x1b[40m";
+            public static string Black
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[40m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color red.
             /// </summary>
-            public static string Red { get; } = "\x1b[41m";
+            public static string Red
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[41m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color green.
             /// </summary>
-            public static string Green { get; } = "\x1b[42m";
+            public static string Green
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[42m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color yellow.
             /// </summary>
-            public static string Yellow { get; } = "\x1b[43m";
+            public static string Yellow
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[43m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color blue.
             /// </summary>
-            public static string Blue { get; } = "\x1b[44m";
+            public static string Blue
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[44m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color magenta.
             /// </summary>
-            public static string Magenta { get; } = "\x1b[45m";
+            public static string Magenta
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[45m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color cyan.
             /// </summary>
-            public static string Cyan { get; } = "\x1b[46m";
+            public static string Cyan
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[46m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color white.
             /// </summary>
-            public static string White { get; } = "\x1b[47m";
+            public static string White
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[47m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright black.
             /// </summary>
-            public static string BrightBlack { get; } = "\x1b[100m";
+            public static string BrightBlack
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[100m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright red.
             /// </summary>
-            public static string BrightRed { get; } = "\x1b[101m";
+            public static string BrightRed
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[101m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright green.
             /// </summary>
-            public static string BrightGreen { get; } = "\x1b[102m";
+            public static string BrightGreen
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[102m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright yellow.
             /// </summary>
-            public static string BrightYellow { get; } = "\x1b[103m";
+            public static string BrightYellow
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[103m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright blue.
             /// </summary>
-            public static string BrightBlue { get; } = "\x1b[104m";
+            public static string BrightBlue
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[104m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright magenta.
             /// </summary>
-            public static string BrightMagenta { get; } = "\x1b[105m";
+            public static string BrightMagenta
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[105m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright cyan.
             /// </summary>
-            public static string BrightCyan { get; } = "\x1b[106m";
+            public static string BrightCyan
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[106m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright white.
             /// </summary>
-            public static string BrightWhite { get; } = "\x1b[107m";
+            public static string BrightWhite
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[107m" : "";
+                }
+            }
         }
 
         /// <summary>
@@ -115,104 +213,230 @@ namespace Microsoft.WindowsAzure.Commands.Common
             /// <summary>
             /// Gets the color black.
             /// </summary>
-            public static string Black { get; } = "\x1b[30m";
+            public static string Black
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[30m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color red.
             /// </summary>
-            public static string Red { get; } = "\x1b[31m";
+            public static string Red
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[31m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color green.
             /// </summary>
-            public static string Green { get; } = "\x1b[32m";
+            public static string Green
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[32m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color yellow.
             /// </summary>
-            public static string Yellow { get; } = "\x1b[33m";
+            public static string Yellow
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[33m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color blue.
             /// </summary>
-            public static string Blue { get; } = "\x1b[34m";
+            public static string Blue
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[34m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color magenta.
             /// </summary>
-            public static string Magenta { get; } = "\x1b[35m";
+            public static string Magenta
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[35m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color cyan.
             /// </summary>
-            public static string Cyan { get; } = "\x1b[36m";
+            public static string Cyan
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[36m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color white.
             /// </summary>
-            public static string White { get; } = "\x1b[37m";
+            public static string White
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[37m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright black.
             /// </summary>
-            public static string BrightBlack { get; } = "\x1b[90m";
+            public static string BrightBlack
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[90m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright red.
             /// </summary>
-            public static string BrightRed { get; } = "\x1b[91m";
+            public static string BrightRed
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[91m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright green.
             /// </summary>
-            public static string BrightGreen { get; } = "\x1b[92m";
+            public static string BrightGreen
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[92m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright yellow.
             /// </summary>
-            public static string BrightYellow { get; } = "\x1b[93m";
+            public static string BrightYellow
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[93m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright blue.
             /// </summary>
-            public static string BrightBlue { get; } = "\x1b[94m";
+            public static string BrightBlue
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[94m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright magenta.
             /// </summary>
-            public static string BrightMagenta { get; } = "\x1b[95m";
+            public static string BrightMagenta
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[95m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright cyan.
             /// </summary>
-            public static string BrightCyan { get; } = "\x1b[96m";
+            public static string BrightCyan
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[96m" : "";
+                }
+            }
 
             /// <summary>
             /// Gets the color bright white.
             /// </summary>
-            public static string BrightWhite { get; } = "\x1b[97m";
+            public static string BrightWhite
+            {
+                get
+                {
+                    return SupportsVirtualTerminal == true ? "\x1b[97m" : "";
+                }
+            }
         }
 
-        public static string Reset { get; } = "\x1b[0m";
+        public static string Reset
+        {
+            get
+            {
+                return SupportsVirtualTerminal == true ? "\x1b[0m" : "";
+            }
+        }
 
         /// <summary>
         /// Gets value to turn off underlined.
         /// </summary>
-        public static string UnderlineOff { get; } = "\x1b[24m";
+        public static string UnderlineOff
+        {
+            get
+            {
+                return SupportsVirtualTerminal == true ? "\x1b[24m" : "";
+            }
+        }
 
         /// <summary>
         /// Gets value to turn on underlined.
         /// </summary>
-        public static string Underline { get; } = "\x1b[4m";
+        public static string Underline
+        {
+            get
+            {
+                return SupportsVirtualTerminal == true ? "\x1b[4m" : "";
+            }
+        }
 
         /// <summary>
         /// Gets value to turn off bold.
         /// </summary>
-        public static string BoldOff { get; } = "\x1b[22m";
+        public static string BoldOff
+        {
+            get
+            {
+                return SupportsVirtualTerminal == true ? "\x1b[22m" : "";
+            }
+        }
 
         /// <summary>
         /// Gets value to turn on bold.
         /// </summary>
-        public static string Bold { get; } = "\x1b[1m";
+        public static string Bold
+        {
+            get
+            {
+                return SupportsVirtualTerminal == true ? "\x1b[1m" : "";
+            }
+        }
     }
 }


### PR DESCRIPTION
- Fix issue: https://github.com/Azure/azure-powershell/issues/24556

- Group in Azure-PowerShell PR: https://github.com/Azure/azure-powershell/pull/25735

- Current effect
![image](https://github.com/user-attachments/assets/8d0505e1-37de-42bb-bcac-b3e616673695)

- Changed effect
![image](https://github.com/user-attachments/assets/d2f357b8-22ac-4028-a615-2c9136c3dfc0)

