### PR TITLE
set subscription id and tenant id in telemetry if it's null

### DIFF
--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -343,17 +343,9 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 eventProperties.Add("UserId", qos.Uid);
             }
-            if (null == qos.SubscriptionId )
-            {
-                qos.SubscriptionId = AzureRmProfileProvider.Instance?.Profile?.DefaultContext?.Subscription?.Id;
-            }
             if (qos.SubscriptionId != null)
             {
                 eventProperties.Add("subscription-id", qos.SubscriptionId);
-            }
-            if (null == qos.TenantId)
-            {
-                qos.TenantId = AzureRmProfileProvider.Instance?.Profile?.DefaultContext?.Tenant?.Id;
             }
             if (qos.TenantId != null)
             {

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -343,9 +343,17 @@ namespace Microsoft.WindowsAzure.Commands.Common
             {
                 eventProperties.Add("UserId", qos.Uid);
             }
+            if (null == qos.SubscriptionId )
+            {
+                qos.SubscriptionId = AzureRmProfileProvider.Instance?.Profile?.DefaultContext?.Subscription?.Id;
+            }
             if (qos.SubscriptionId != null)
             {
                 eventProperties.Add("subscription-id", qos.SubscriptionId);
+            }
+            if (null == qos.TenantId)
+            {
+                qos.TenantId = AzureRmProfileProvider.Instance?.Profile?.DefaultContext?.Tenant?.Id;
             }
             if (qos.TenantId != null)
             {

--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -281,6 +281,22 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
             return result;
         }
 
+        protected override void EndProcessing()
+        {
+            IAzureContext context;
+            _qosEvent.Uid = "defaultid";
+            if (RequireDefaultContext() && TryGetDefaultContext(out context))
+            {
+                _qosEvent.SubscriptionId = context.Subscription?.Id;
+                _qosEvent.TenantId = context.Tenant?.Id;
+                if (context.Account != null && !String.IsNullOrWhiteSpace(context.Account.Id))
+                {
+                    _qosEvent.Uid = MetricHelper.GenerateSha256HashString(context.Account.Id.ToString());
+                }
+            }
+            base.EndProcessing();
+        }
+
         /// <summary>
         /// Gets the current default context.
         /// </summary>
@@ -380,17 +396,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
         {
             base.InitializeQosEvent();
 
-            IAzureContext context;
-            _qosEvent.Uid = "defaultid";
-            if (RequireDefaultContext() && TryGetDefaultContext(out context))
-            {
-                _qosEvent.SubscriptionId = context.Subscription?.Id;
-                _qosEvent.TenantId = context.Tenant?.Id;
-                if (context.Account != null && !String.IsNullOrWhiteSpace(context.Account.Id))
-                {
-                    _qosEvent.Uid = MetricHelper.GenerateSha256HashString(context.Account.Id.ToString());
-                }
-            }
+            
         }
 
         protected override void LogCmdletStartInvocationInfo()

--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
         {
             IAzureContext context;
             _qosEvent.Uid = "defaultid";
-            if (RequireDefaultContext() && TryGetDefaultContext(out context))
+            if (TryGetDefaultContext(out context) && context != null)
             {
                 _qosEvent.SubscriptionId = context.Subscription?.Id;
                 _qosEvent.TenantId = context.Tenant?.Id;


### PR DESCRIPTION
It's for `Content-AzAccount`. When it's run, the subscription id and tenant id is not set in context. That's why they are empty in telemetry.
This PR is going to set them before recording the telemetry.