### PR TITLE
Set UserAgent for ARM telemetry

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -800,7 +800,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             _qosEvent.SanitizerInfo = new SanitizerTelemetry(OutputSanitizer?.RequireSecretsDetection == true);
         }
 
-        public static string getEnvUserAgent()
+        private static string getEnvUserAgent()
         {
             string hostEnv = Environment.GetEnvironmentVariable("AZUREPS_HOST_ENVIRONMENT");
             if (String.IsNullOrWhiteSpace(hostEnv))

--- a/src/Common/CmdletInfoHandler.cs
+++ b/src/Common/CmdletInfoHandler.cs
@@ -57,10 +57,18 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             if (Cmdlet != null)
             {
+                if (request.Headers.Contains("CommandName"))
+                {
+                    request.Headers.Remove("CommandName");
+                }
                 request.Headers.Add("CommandName", Cmdlet);
             }
             if (ParameterSet != null)
             {
+                if (request.Headers.Contains("ParameterSetName"))
+                {
+                    request.Headers.Remove("ParameterSetName");
+                }
                 request.Headers.Add("ParameterSetName", ParameterSet);
             }
             if (ClientRequestId != null)


### PR DESCRIPTION
This PR is to set UserAgent for ARM request in case of SDK-based cmdlets.
And it fixes the bug of dumplicated CommandName and ParameterSetName.