### PR TITLE
Update telemetry data to add moniker of the detected properties

### DIFF
--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -433,13 +433,13 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                 var sanitizerInfo = _qosEvent.SanitizerInfo;
                 if (sanitizerInfo.ShowSecretsWarning && sanitizerInfo.SecretsDetected)
                 {
-                    if (sanitizerInfo.DetectedProperties.Count == 0)
+                    if (sanitizerInfo.DetectedProperties.IsEmpty)
                     {
                         WriteWarning(string.Format(Resources.DisplaySecretsWarningMessageWithoutProperty, MyInvocation.InvocationName));
                     }
                     else
                     {
-                        WriteWarning(string.Format(Resources.DisplaySecretsWarningMessageWithProperty, MyInvocation.InvocationName, string.Join(", ", sanitizerInfo.DetectedProperties)));
+                        WriteWarning(string.Format(Resources.DisplaySecretsWarningMessageWithProperty, MyInvocation.InvocationName, string.Join(", ", sanitizerInfo.DetectedProperties.PropertyNames)));
                     }
                 }
             }

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -481,8 +481,29 @@ namespace Microsoft.WindowsAzure.Commands.Common
                     eventProperties["secrets-detected"] = secretsDetected.ToString();
                     if (secretsDetected)
                     {
-                        var detectedProperties = qos.SanitizerInfo.DetectedProperties.Count == 0 ? "[None]" : string.Join(";", qos.SanitizerInfo.DetectedProperties);
-                        eventProperties.Add("secrets-detected-properties", detectedProperties);
+                        string detectedProperties = string.Empty;
+                        if (qos.SanitizerInfo.DetectedProperties.IsEmpty)
+                        {
+                            eventProperties.Add("secrets-detected-properties", "[None]");
+                        }
+                        else
+                        {
+                            var sbDetectedProperties = new StringBuilder();
+                            sbDetectedProperties.Append("[");
+                            foreach (var detectedProperty in qos.SanitizerInfo.DetectedProperties)
+                            {
+                                sbDetectedProperties.Append("{");
+
+                                sbDetectedProperties.Append($"\"name\": \"{detectedProperty.Key}\",");
+                                sbDetectedProperties.Append($"\"correlatingid\": \"{string.Join(";", detectedProperty.Value.CrossCompanyCorrelatingIds)}\",");
+                                sbDetectedProperties.Append($"\"moniker\": \"{string.Join(";", detectedProperty.Value.Monikers)}\"");
+
+                                sbDetectedProperties.Append("},");
+                            }
+                            sbDetectedProperties.Length--;
+                            sbDetectedProperties.Append("]");
+                            eventProperties.Add("secrets-detected-properties", sbDetectedProperties.ToString());
+                        }
                     }
                     if (qos.SanitizerInfo.HasErrorInDetection && qos.SanitizerInfo.DetectionError != null)
                     {

--- a/src/Common/MetricHelper.cs
+++ b/src/Common/MetricHelper.cs
@@ -494,9 +494,8 @@ namespace Microsoft.WindowsAzure.Commands.Common
                             {
                                 sbDetectedProperties.Append("{");
 
-                                sbDetectedProperties.Append($"\"name\": \"{detectedProperty.Key}\",");
-                                sbDetectedProperties.Append($"\"correlatingid\": \"{string.Join(";", detectedProperty.Value.CrossCompanyCorrelatingIds)}\",");
-                                sbDetectedProperties.Append($"\"moniker\": \"{string.Join(";", detectedProperty.Value.Monikers)}\"");
+                                sbDetectedProperties.Append($"\"name\":\"{detectedProperty.Key}\",");
+                                sbDetectedProperties.Append($"\"moniker\":\"{string.Join(";", detectedProperty.Value)}\"");
 
                                 sbDetectedProperties.Append("},");
                             }

--- a/src/Common/Sanitizer/SanitizerTelemetry.cs
+++ b/src/Common/Sanitizer/SanitizerTelemetry.cs
@@ -18,41 +18,39 @@ using System.Collections.Generic;
 
 namespace Microsoft.WindowsAzure.Commands.Common.Sanitizer
 {
-    public class DetectedPropertiesInfo : IEnumerable<KeyValuePair<string, (HashSet<string> CrossCompanyCorrelatingIds, HashSet<string> Monikers)>>
+    public class DetectedPropertiesInfo : IEnumerable<KeyValuePair<string, HashSet<string>>>
     {
-        private readonly Dictionary<string, (HashSet<string> CrossCompanyCorrelatingIds, HashSet<string> Monikers)> _internalProperties;
+        private readonly Dictionary<string, HashSet<string>> _internalProperties;
 
         public DetectedPropertiesInfo()
         {
-            _internalProperties = new Dictionary<string, (HashSet<string> CrossCompanyCorrelatingIds, HashSet<string> Monikers)>();
+            _internalProperties = new Dictionary<string, HashSet<string>>();
         }
 
         public bool IsEmpty => _internalProperties.Count == 0;
 
         public IEnumerable<string> PropertyNames => _internalProperties.Keys;
 
-        public void AddPropertyInfo(string propertyName, string crossCompanyCorrelatingId, string moniker)
+        public void AddPropertyInfo(string propertyName, string moniker)
         {
             if (!_internalProperties.TryGetValue(propertyName, out var propertyInfo))
             {
-                propertyInfo = (new HashSet<string>(), new HashSet<string>());
+                propertyInfo = new HashSet<string>();
                 _internalProperties[propertyName] = propertyInfo;
             }
 
-            propertyInfo.CrossCompanyCorrelatingIds.Add(crossCompanyCorrelatingId);
-            propertyInfo.Monikers.Add(moniker);
+            propertyInfo.Add(moniker);
         }
 
-        public void AddPropertyInfo(string propertyName, HashSet<string> crossCompanyCorrelatingIds, HashSet<string> monikers)
+        public void AddPropertyInfo(string propertyName, HashSet<string> monikers)
         {
             if (!_internalProperties.TryGetValue(propertyName, out var propertyInfo))
             {
-                propertyInfo = (new HashSet<string>(), new HashSet<string>());
+                propertyInfo = new HashSet<string>();
                 _internalProperties[propertyName] = propertyInfo;
             }
 
-            propertyInfo.CrossCompanyCorrelatingIds.UnionWith(crossCompanyCorrelatingIds);
-            propertyInfo.Monikers.UnionWith(monikers);
+            propertyInfo.UnionWith(monikers);
         }
 
         public bool ContainsProperty(string propertyName)
@@ -60,7 +58,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.Sanitizer
             return _internalProperties.ContainsKey(propertyName);
         }
 
-        public IEnumerator<KeyValuePair<string, (HashSet<string> CrossCompanyCorrelatingIds, HashSet<string> Monikers)>> GetEnumerator()
+        public IEnumerator<KeyValuePair<string, HashSet<string>>> GetEnumerator()
         {
             return _internalProperties.GetEnumerator();
         }
@@ -104,7 +102,7 @@ namespace Microsoft.WindowsAzure.Commands.Common.Sanitizer
                 SanitizeDuration += telemetry.SanitizeDuration;
                 foreach (var property in telemetry.DetectedProperties)
                 {
-                    DetectedProperties.AddPropertyInfo(property.Key, property.Value.CrossCompanyCorrelatingIds, property.Value.Monikers);
+                    DetectedProperties.AddPropertyInfo(property.Key, property.Value);
                 }
             }
         }

--- a/src/Common/Sanitizer/SanitizerTelemetry.cs
+++ b/src/Common/Sanitizer/SanitizerTelemetry.cs
@@ -13,27 +13,84 @@
 // ----------------------------------------------------------------------------------
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Microsoft.WindowsAzure.Commands.Common.Sanitizer
 {
+    public class DetectedPropertiesInfo : IEnumerable<KeyValuePair<string, (HashSet<string> CrossCompanyCorrelatingIds, HashSet<string> Monikers)>>
+    {
+        private readonly Dictionary<string, (HashSet<string> CrossCompanyCorrelatingIds, HashSet<string> Monikers)> _internalProperties;
+
+        public DetectedPropertiesInfo()
+        {
+            _internalProperties = new Dictionary<string, (HashSet<string> CrossCompanyCorrelatingIds, HashSet<string> Monikers)>();
+        }
+
+        public bool IsEmpty => _internalProperties.Count == 0;
+
+        public IEnumerable<string> PropertyNames => _internalProperties.Keys;
+
+        public void AddPropertyInfo(string propertyName, string crossCompanyCorrelatingId, string moniker)
+        {
+            if (!_internalProperties.TryGetValue(propertyName, out var propertyInfo))
+            {
+                propertyInfo = (new HashSet<string>(), new HashSet<string>());
+                _internalProperties[propertyName] = propertyInfo;
+            }
+
+            propertyInfo.CrossCompanyCorrelatingIds.Add(crossCompanyCorrelatingId);
+            propertyInfo.Monikers.Add(moniker);
+        }
+
+        public void AddPropertyInfo(string propertyName, HashSet<string> crossCompanyCorrelatingIds, HashSet<string> monikers)
+        {
+            if (!_internalProperties.TryGetValue(propertyName, out var propertyInfo))
+            {
+                propertyInfo = (new HashSet<string>(), new HashSet<string>());
+                _internalProperties[propertyName] = propertyInfo;
+            }
+
+            propertyInfo.CrossCompanyCorrelatingIds.UnionWith(crossCompanyCorrelatingIds);
+            propertyInfo.Monikers.UnionWith(monikers);
+        }
+
+        public bool ContainsProperty(string propertyName)
+        {
+            return _internalProperties.ContainsKey(propertyName);
+        }
+
+        public IEnumerator<KeyValuePair<string, (HashSet<string> CrossCompanyCorrelatingIds, HashSet<string> Monikers)>> GetEnumerator()
+        {
+            return _internalProperties.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
     public class SanitizerTelemetry
     {
-        public bool ShowSecretsWarning { get; set; } = false;
+        public bool ShowSecretsWarning { get; set; }
 
-        public bool SecretsDetected { get; set; } = false;
+        public bool SecretsDetected { get; set; }
 
-        public HashSet<string> DetectedProperties { get; set; } = new HashSet<string>();
-
-        public bool HasErrorInDetection { get; set; } = false;
+        public bool HasErrorInDetection { get; set; }
 
         public Exception DetectionError { get; set; }
 
         public TimeSpan SanitizeDuration { get; set; }
 
+        public DetectedPropertiesInfo DetectedProperties { get; private set; }
+
         public SanitizerTelemetry(bool showSecretsWarning)
         {
             ShowSecretsWarning = showSecretsWarning;
+            SecretsDetected = false;
+            HasErrorInDetection = false;
+            DetectedProperties = new DetectedPropertiesInfo();
         }
 
         public void Combine(SanitizerTelemetry telemetry)
@@ -42,10 +99,13 @@ namespace Microsoft.WindowsAzure.Commands.Common.Sanitizer
             {
                 ShowSecretsWarning = ShowSecretsWarning || telemetry.ShowSecretsWarning;
                 SecretsDetected = SecretsDetected || telemetry.SecretsDetected;
-                DetectedProperties.UnionWith(telemetry.DetectedProperties);
                 HasErrorInDetection = HasErrorInDetection || telemetry.HasErrorInDetection;
                 DetectionError = DetectionError ?? telemetry.DetectionError;
                 SanitizeDuration += telemetry.SanitizeDuration;
+                foreach (var property in telemetry.DetectedProperties)
+                {
+                    DetectedProperties.AddPropertyInfo(property.Key, property.Value.CrossCompanyCorrelatingIds, property.Value.Monikers);
+                }
             }
         }
     }


### PR DESCRIPTION
This pull request includes several changes aimed at improving the handling and representation of detected properties in the sanitizer telemetry. The most important changes include the introduction of a new `DetectedPropertiesInfo` class, updates to the `SanitizerTelemetry` class to use this new class, and modifications to methods that interact with detected properties.

### Improvements to Detected Properties Handling:

* **New `DetectedPropertiesInfo` Class**:
  * Introduced `DetectedPropertiesInfo` to encapsulate detected properties and provide methods for adding and querying properties. (`src/Common/Sanitizer/SanitizerTelemetry.cs`, [src/Common/Sanitizer/SanitizerTelemetry.csR16-R91](diffhunk://#diff-f8410eb640aeb4660d721f15e982a3a77511ec4cdd1853677cab393f15e150edR16-R91))

* **Updates to `SanitizerTelemetry` Class**:
  * Modified `SanitizerTelemetry` to use `DetectedPropertiesInfo` instead of a `HashSet<string>`. Added methods to combine detected properties from multiple telemetry instances. (`src/Common/Sanitizer/SanitizerTelemetry.cs`, [src/Common/Sanitizer/SanitizerTelemetry.csL45-R106](diffhunk://#diff-f8410eb640aeb4660d721f15e982a3a77511ec4cdd1853677cab393f15e150edL45-R106))
  * Updated the constructor of `SanitizerTelemetry` to initialize `DetectedProperties` as an instance of `DetectedPropertiesInfo`. (`src/Common/Sanitizer/SanitizerTelemetry.cs`, [src/Common/Sanitizer/SanitizerTelemetry.csR16-R91](diffhunk://#diff-f8410eb640aeb4660d721f15e982a3a77511ec4cdd1853677cab393f15e150edR16-R91))

### Method Modifications:

* **`WriteSecretsWarningMessage` Method**:
  * Updated the condition to check if detected properties are empty using the new `IsEmpty` property of `DetectedPropertiesInfo`. Adjusted the warning message to use `PropertyNames` from `DetectedPropertiesInfo`. (`src/Common/AzurePSCmdlet.cs`, [src/Common/AzurePSCmdlet.csL436-R442](diffhunk://#diff-f502b3fb26d4e039f1601ef76310ed87b79ca228f407f9104d757acc71397f2aL436-R442))

* **`PopulateSanitizerPropertiesFromQos` Method**:
  * Refactored to build a detailed string representation of detected properties using the new `DetectedPropertiesInfo` class. (`src/Common/MetricHelper.cs`, [src/Common/MetricHelper.csL484-R505](diffhunk://#diff-0f9d296b3dad298511aecba78fe450dee495967ad9f21b4ea0d468cba7a3022dL484-R505))