### PR TITLE
fix race condition in dictionary operations

### DIFF
--- a/src/Authentication.Abstractions/AzureSession.cs
+++ b/src/Authentication.Abstractions/AzureSession.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Azure.Commands.Common.Authentication
         static IAzureSession _instance;
         static bool _initialized = false;
         static ReaderWriterLockSlim sessionLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
-        private IDictionary<ComponentKey, object> _componentRegistry = new ConcurrentDictionary<ComponentKey, object>(new ComponentKeyComparer());
+        // explicit typing for the thread-safe API calls to avoid the need for explicit casting
+        private ConcurrentDictionary<ComponentKey, object> _componentRegistry = new ConcurrentDictionary<ComponentKey, object>(new ComponentKeyComparer());
         private event EventHandler<AzureSessionEventArgs> _eventHandler;
 
         /// <summary>
@@ -263,8 +264,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication
                 () =>
                 {
                     var key = new ComponentKey(componentName, typeof(T));
-                    var components = _componentRegistry as ConcurrentDictionary<ComponentKey, object>;
-                    if (components.TryRemove(key, out var component) && component is IAzureSessionListener listener)
+                    if (_componentRegistry.TryRemove(key, out var component) && component is IAzureSessionListener listener)
                     {
                         _eventHandler -= listener.OnEvent;
                     }

--- a/src/Authentication.Abstractions/AzureSession.cs
+++ b/src/Authentication.Abstractions/AzureSession.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication
         public string OldProfileFile { get; set; }
 
         /// <summary>
-        /// The directory contianing the ARM ContextContainer
+        /// The directory containing the ARM ContextContainer
         /// </summary>
         public string ARMProfileDirectory { get; set; }
 
@@ -214,13 +214,16 @@ namespace Microsoft.Azure.Commands.Common.Authentication
         public bool TryGetComponent<T>(string componentName, out T component) where T : class
         {
             var key = new ComponentKey(componentName, typeof(T));
-            component = null;
-            if (_componentRegistry.ContainsKey(key))
+            if (_componentRegistry.TryGetValue(key, out var componentObj) && componentObj is T componentT)
             {
-                component = _componentRegistry[key] as T;
+                component = componentT;
+                return true;
             }
-
-            return component != null;
+            else
+            {
+                component = null;
+                return false;
+            }
         }
 
         public void RegisterComponent<T>(string componentName, Func<T> componentInitializer) where T : class
@@ -234,6 +237,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication
                 () =>
                 {
                     var key = new ComponentKey(componentName, typeof(T));
+                    // todo: double check if dictionary operations are thread safe
                     if (!_componentRegistry.ContainsKey(key) || overwrite)
                     {
                         if (_componentRegistry.ContainsKey(key) && overwrite)
@@ -260,6 +264,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication
                 () =>
                 {
                     var key = new ComponentKey(componentName, typeof(T));
+                    // todo: double check if dictionary operations are thread safe
                     if (_componentRegistry.ContainsKey(key))
                     {
                         var component = _componentRegistry[key];


### PR DESCRIPTION
Fix Azure/azure-powershell#26624

This pull request Improved the `AzureSession.TryGetComponent` method to use `TryGetValue` instead of `ContainsKey` plus `[]` to avoid potential race condition between the two operations.