### PR TITLE
Add ResourceId and Suffix in Mooncake and USGov for App Configuration.

### DIFF
--- a/src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs
@@ -175,6 +175,8 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.ChinaAnalysisServicesEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.ChinaManagedHsmServiceEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointSuffix, AzureEnvironmentConstants.ChinaManagedHsmDnsSuffix);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointResourceId, AzureEnvironmentConstants.ChinaAppConfigurationEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointSuffix, AzureEnvironmentConstants.ChinaAppConfigurationEndpointSuffix);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.ChinaContainerRegistryEndpointResourceId);
             }
 
@@ -186,6 +188,8 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AnalysisServicesEndpointResourceId, AzureEnvironmentConstants.USGovernmentAnalysisServicesEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointResourceId, AzureEnvironmentConstants.USGovernmeneManagedHsmServiceEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ManagedHsmServiceEndpointSuffix, AzureEnvironmentConstants.USGovernmentManagedHsmDnsSuffix);
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointResourceId, AzureEnvironmentConstants.USGovernmentAppConfigurationEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointSuffix, AzureEnvironmentConstants.USGovernmentAppConfigurationEndpointSuffix);
                 azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.USGovernmentContainerRegistryEndpointResourceId);
             }
         } 

--- a/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
+++ b/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
@@ -269,10 +269,18 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         public const string AzurePurviewEndpointResourceId = "https://purview.azure.net";
 
         /// <summary>
-        /// App Configuration
+        /// The domain name suffix for App Configuration
         /// </summary>
         public const string AzureAppConfigurationEndpointSuffix = "azconfig.io";
+        public const string ChinaAppConfigurationEndpointSuffix = "azconfig.azure.cn";
+        public const string USGovernmentAppConfigurationEndpointSuffix = "azconfig.azure.us";
+
+        /// <summary>
+        /// The endpoint Resource Id for App Configuration
+        /// </summary>
         public const string AzureAppConfigurationEndpointResourceId = "https://azconfig.io";
+        public const string ChinaAppConfigurationEndpointResourceId = "https://azconfig.azure.cn";
+        public const string USGovernmentAppConfigurationEndpointResourceId = "https://azconfig.azure.us";
 
         /// <summary>
         /// The endpoint Resource Id for Azure Container Registry


### PR DESCRIPTION
This pull request includes changes to extend the Azure environment properties by adding new endpoints for the Azure App Configuration service across different Azure environments. The most important changes include updates to the `SetExtendedProperties` method and the `AzureEnvironmentConstants` class to incorporate these new endpoints.

### Updates to Azure environment properties:

* [`src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs`](diffhunk://#diff-c24c28d5930881966ac816557a7fe4ba0a031793b2b45d3a20b2e708e0906ab6R178-R179): Added properties for `AzureAppConfigurationEndpointResourceId` and `AzureAppConfigurationEndpointSuffix` for the `AzureChinaCloud` environment.
* [`src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs`](diffhunk://#diff-c24c28d5930881966ac816557a7fe4ba0a031793b2b45d3a20b2e708e0906ab6R191-R192): Added properties for `AzureAppConfigurationEndpointResourceId` and `AzureAppConfigurationEndpointSuffix` for the `AzureUSGovernment` environment.

### Updates to Azure environment constants:

* [`src/Authentication.Abstractions/AzureEnvironmentConstants.cs`](diffhunk://#diff-dafae142f0cd7ea02cc4c695dd7c4e1a144898b11380ca73f0b4c2162c5aeecaL272-R283): Added constants for `ChinaAppConfigurationEndpointSuffix`, `USGovernmentAppConfigurationEndpointSuffix`, `ChinaAppConfigurationEndpointResourceId`, and `USGovernmentAppConfigurationEndpointResourceId`.