### PR TITLE
Fix that RemoveUser Doesn't Work When Create Public Client with Broker

### DIFF
--- a/src/Authentication.Abstractions/Interfaces/IAuthenticationFactory.cs
+++ b/src/Authentication.Abstractions/Interfaces/IAuthenticationFactory.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// Remove any stored credentials for the given user and the Azure environment used.
         /// </summary>
         /// <param name="account">The account to remove credentials for</param>
-        /// <param name="authority">The Microsoft Entra authority</param>
-        void RemoveUser(IAzureAccount account, string authority);
+        /// <param name="environment">The environment which account belongs to</param>
+        void RemoveUser(IAzureAccount account, IAzureEnvironment environment);
     }
 }

--- a/src/Authentication.Abstractions/Interfaces/IAuthenticationFactory.cs
+++ b/src/Authentication.Abstractions/Interfaces/IAuthenticationFactory.cs
@@ -133,6 +133,15 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// </summary>
         /// <param name="account">The account to remove credentials for</param>
         /// <param name="tokenCache">The TokenCache to remove credentials from</param>
+        [Obsolete("RemoveUser is deprecated, please use RemoveUser with Azure environment instead.", true)]
         void RemoveUser(IAzureAccount account, IAzureTokenCache tokenCache);
+
+
+        /// <summary>
+        /// Remove any stored credentials for the given user and the Azure environment used.
+        /// </summary>
+        /// <param name="account">The account to remove credentials for</param>
+        /// <param name="authority">The Microsoft Entra authority</param>
+        void RemoveUser(IAzureAccount account, string authority);
     }
 }


### PR DESCRIPTION
Add a new interface of "RemoveUser" to accept authority as the input for Authority from environment is required to decide whether public client should be created with broker or not.