### PR TITLE
Force using the same Newtonsoft.Json version for all projects.

### DIFF
--- a/src/Storage.Management/Storage.Management.csproj
+++ b/src/Storage.Management/Storage.Management.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OmitJsonPackage>true</OmitJsonPackage>
-  </PropertyGroup>
   <Import Project="$(ProjectDir)..\Dependencies.Client.targets" />
 
   <PropertyGroup>

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -1,8 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OmitJsonPackage>true</OmitJsonPackage>
-  </PropertyGroup>
-
   <Import Project="$(ProjectDir)..\Dependencies.targets" />
 
   <PropertyGroup>


### PR DESCRIPTION
This PR removes the attribute <OmitJsonPackage> to forcefully use the same Newtonsoft.Json among all projects defined in the Dependencies.targets.