### PR TITLE
Added SSH auth scope to environment

### DIFF
--- a/src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.BuiltIn.cs
@@ -165,6 +165,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.AzureContainerRegistryEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureCommunicationEmailEndpointSuffix, AzureEnvironmentConstants.AzureCommunicationEmailEndpointSuffix);
                 azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureCommunicationEmailEndpointResourceId, AzureEnvironmentConstants.AzureCommunicationEmailEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureCloud].SetProperty(ExtendedEndpoint.AzureSshAuthScope, AzureEnvironmentConstants.AzureSshAuthScope);
             }
 
             if (azureEnvironments.ContainsKey(EnvironmentName.AzureChinaCloud))
@@ -178,6 +179,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointResourceId, AzureEnvironmentConstants.ChinaAppConfigurationEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointSuffix, AzureEnvironmentConstants.ChinaAppConfigurationEndpointSuffix);
                 azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.ChinaContainerRegistryEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureChinaCloud].SetProperty(ExtendedEndpoint.AzureSshAuthScope, AzureEnvironmentConstants.ChinaSshAuthScope);
             }
 
             if (azureEnvironments.ContainsKey(EnvironmentName.AzureUSGovernment))
@@ -191,6 +193,7 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointResourceId, AzureEnvironmentConstants.USGovernmentAppConfigurationEndpointResourceId);
                 azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AzureAppConfigurationEndpointSuffix, AzureEnvironmentConstants.USGovernmentAppConfigurationEndpointSuffix);
                 azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.ContainerRegistryEndpointResourceId, AzureEnvironmentConstants.USGovernmentContainerRegistryEndpointResourceId);
+                azureEnvironments[EnvironmentName.AzureUSGovernment].SetProperty(ExtendedEndpoint.AzureSshAuthScope, AzureEnvironmentConstants.USGovernmentSshAuthScope);
             }
         } 
     }

--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -571,7 +571,8 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                 AzureAppConfigurationEndpointResourceId = "AzureAppConfigurationEndpointResourceId",
                 ContainerRegistryEndpointResourceId = "ContainerRegistryEndpointResourceId",
                 AzureCommunicationEmailEndpointSuffix = "AzureCommunicationEmailEndpointSuffix",
-                AzureCommunicationEmailEndpointResourceId = "AzureCommunicationEmailEndpointResourceId";
+                AzureCommunicationEmailEndpointResourceId = "AzureCommunicationEmailEndpointResourceId",
+                AzureSshAuthScope = "AzureSshAuthScope";
         }
     }
 }

--- a/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
+++ b/src/Authentication.Abstractions/AzureEnvironmentConstants.cs
@@ -294,5 +294,12 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
         /// </summary>
         public const string AzureCommunicationEmailEndpointSuffix = "communication.azure.com";
         public const string AzureCommunicationEmailEndpointResourceId = "https://communication.azure.com";
+
+        /// <summary>
+        /// The scope for SSH authentication. See <see cref="SshCredentialFactory"/>
+        /// </summary>
+        public const string AzureSshAuthScope = "https://pas.windows.net/CheckMyAccess/Linux/.default";
+        public const string ChinaSshAuthScope = "https://pas.chinacloudapi.cn/CheckMyAccess/Linux/.default";
+        public const string USGovernmentSshAuthScope = "https://pasff.usgovcloudapi.net/CheckMyAccess/Linux/.default";
     }
 }

--- a/src/Authentication.Abstractions/Extensions/AzureEnvironmentExtensions.cs
+++ b/src/Authentication.Abstractions/Extensions/AzureEnvironmentExtensions.cs
@@ -328,6 +328,9 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
                     case AzureEnvironment.ExtendedEndpoint.AzureCommunicationEmailEndpointResourceId:
                         environment.SetProperty(AzureEnvironment.ExtendedEndpoint.AzureCommunicationEmailEndpointResourceId, propertyValue);
                         break;
+                    case AzureEnvironment.ExtendedEndpoint.AzureSshAuthScope:
+                        environment.SetProperty(AzureEnvironment.ExtendedEndpoint.AzureSshAuthScope, propertyValue);
+                        break;
                 }
             }
         }


### PR DESCRIPTION
To enable updating the auth scope, this PR adds it to the environment. There will be a follow-up PR to update `Set-AzEnvironment` and logic in `SshCredentialFactory` in azure-powershell repo.