### PR TITLE
[ChangeSafety] Phase 1: AcquirePolicyToken Support

### DIFF
--- a/Azure.PowerShell.Common.sln
+++ b/Azure.PowerShell.Common.sln
@@ -45,6 +45,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Authentication.Abstractions
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Share", "src\Share\Share.csproj", "{29ECE00D-4FD5-4AFC-BEBF-136002E9CB9C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0E65A146-80EC-4288-A5E4-69A0C145A52B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Test", "src\Common.Test\Common.Test.csproj", "{F902EB13-6136-4778-BF9A-E179967AB279}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +131,10 @@ Global
 		{29ECE00D-4FD5-4AFC-BEBF-136002E9CB9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29ECE00D-4FD5-4AFC-BEBF-136002E9CB9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{29ECE00D-4FD5-4AFC-BEBF-136002E9CB9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F902EB13-6136-4778-BF9A-E179967AB279}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F902EB13-6136-4778-BF9A-E179967AB279}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F902EB13-6136-4778-BF9A-E179967AB279}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F902EB13-6136-4778-BF9A-E179967AB279}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -136,6 +144,7 @@ Global
 		{6756A7F2-1141-4065-BA23-0C555D2A2BC3} = {625CE04D-FD62-471D-BBCF-E7B716B5FE56}
 		{B571E523-6A04-4EFF-8E89-730078D7FBD1} = {625CE04D-FD62-471D-BBCF-E7B716B5FE56}
 		{E4CBF250-E488-4DE1-B6FC-80341A910F15} = {625CE04D-FD62-471D-BBCF-E7B716B5FE56}
+		{F902EB13-6136-4778-BF9A-E179967AB279} = {0E65A146-80EC-4288-A5E4-69A0C145A52B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4C68FE4-3D0C-4F70-B5BA-499E0C0F177E}

--- a/src/Authentication.Abstractions/Models/ConfigKeysForCommon.cs
+++ b/src/Authentication.Abstractions/Models/ConfigKeysForCommon.cs
@@ -31,5 +31,6 @@ namespace Microsoft.Azure.PowerShell.Common.Config
         public const string CheckForUpgrade = "CheckForUpgrade";
         public const string EnableErrorRecordsPersistence = "EnableErrorRecordsPersistence";
         public const string DisplaySecretsWarning = "DisplaySecretsWarning";
+        public const string EnablePolicyToken = "EnablePolicyToken";
     }
 }

--- a/src/Authentication.Abstractions/Models/ConfigKeysForCommon.cs
+++ b/src/Authentication.Abstractions/Models/ConfigKeysForCommon.cs
@@ -31,6 +31,5 @@ namespace Microsoft.Azure.PowerShell.Common.Config
         public const string CheckForUpgrade = "CheckForUpgrade";
         public const string EnableErrorRecordsPersistence = "EnableErrorRecordsPersistence";
         public const string DisplaySecretsWarning = "DisplaySecretsWarning";
-        public const string EnablePolicyToken = "EnablePolicyToken";
     }
 }

--- a/src/Common.Test/AcquirePolicyTokenHandlerTests.cs
+++ b/src/Common.Test/AcquirePolicyTokenHandlerTests.cs
@@ -1,0 +1,575 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using Microsoft.WindowsAzure.Commands.Common;
+using Microsoft.WindowsAzure.Commands.Utilities.Common;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Commands.Common.Tests
+{
+    // =========================================================================
+    // 1. HANDLER PIPELINE TESTS — Verify the DelegatingHandler behavior
+    // =========================================================================
+    public class AcquirePolicyTokenHandlerTests
+    {
+        #region Clone
+
+        [Fact]
+        public void Clone_ReturnsNewInstance()
+        {
+            var handler = new AcquirePolicyTokenHandler(null);
+            var clone = handler.Clone() as AcquirePolicyTokenHandler;
+
+            Assert.NotNull(clone);
+            Assert.NotSame(handler, clone);
+        }
+
+        #endregion
+
+        #region GET requests are always passed through
+
+        [Fact]
+        public async Task SendAsync_GET_NeverAcquiresToken()
+        {
+            var innerHandler = new MockInnerHandler((req, ct) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa?api-version=2024-01-01");
+
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.False(request.Headers.Contains("x-ms-policy-external-evaluations"),
+                "GET requests must never have the policy token header.");
+        }
+
+        [Fact]
+        public async Task SendAsync_HEAD_NeverAcquiresToken()
+        {
+            var innerHandler = new MockInnerHandler((req, ct) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+            var request = new HttpRequestMessage(HttpMethod.Head,
+                "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/test");
+
+            var response = await client.SendAsync(request);
+            Assert.False(request.Headers.Contains("x-ms-policy-external-evaluations"));
+        }
+
+        #endregion
+
+        #region Write requests without user flag are passed through
+
+        [Theory]
+        [InlineData("PUT")]
+        [InlineData("POST")]
+        [InlineData("DELETE")]
+        [InlineData("PATCH")]
+        public async Task SendAsync_WriteMethod_WithoutUserFlag_NoToken(string method)
+        {
+            // null cmdlet means ShouldAcquirePolicyToken is false
+            var innerHandler = new MockInnerHandler((req, ct) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+            var request = new HttpRequestMessage(new HttpMethod(method),
+                "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa?api-version=2024-01-01");
+
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.False(request.Headers.Contains("x-ms-policy-external-evaluations"),
+                $"{method} without -AcquirePolicyToken must NOT get the header.");
+        }
+
+        #endregion
+
+        #region Existing behavior is not broken — requests still reach the inner handler
+
+        [Fact]
+        public async Task SendAsync_RequestReachesInnerHandler_Always()
+        {
+            bool innerCalled = false;
+            var innerHandler = new MockInnerHandler((req, ct) =>
+            {
+                innerCalled = true;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
+                "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/test"));
+
+            Assert.True(innerCalled, "Inner handler must always be called — existing behavior must not break.");
+        }
+
+        [Fact]
+        public async Task SendAsync_OriginalRequestUnmodified_WhenNoFlag()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var innerHandler = new MockInnerHandler((req, ct) =>
+            {
+                capturedRequest = req;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+            var uri = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/test?api-version=2024-01-01";
+            var request = new HttpRequestMessage(HttpMethod.Put, uri);
+            request.Headers.Add("x-custom", "value");
+
+            await client.SendAsync(request);
+
+            Assert.Equal(uri, capturedRequest.RequestUri.ToString());
+            Assert.True(capturedRequest.Headers.Contains("x-custom"));
+            Assert.False(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"),
+                "No policy header should be added when user didn't request it.");
+        }
+
+        #endregion
+    }
+
+    // =========================================================================
+    // 2. PAYLOAD FORMAT TESTS — Verify the acquirePolicyToken API request body
+    // =========================================================================
+    public class PolicyTokenPayloadTests
+    {
+        [Fact]
+        public void Payload_MatchesAzureCLI_WithChangeReference()
+        {
+            // Azure CLI sends: {"operation": {"uri": ..., "httpMethod": ..., "content": ...}, "changeReference": ...}
+            string changeRef = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ChangeSafety/changeStates/cs/stageProgressions/breakglassStage";
+
+            var payload = new
+            {
+                operation = new
+                {
+                    uri = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa?api-version=2024-01-01",
+                    httpMethod = "DELETE",
+                    content = (object)null
+                },
+                changeReference = changeRef
+            };
+
+            var json = JsonConvert.SerializeObject(payload);
+            var parsed = JObject.Parse(json);
+
+            Assert.NotNull(parsed["operation"]);
+            Assert.Equal("DELETE", parsed["operation"]["httpMethod"].ToString());
+            Assert.Equal(JTokenType.Null, parsed["operation"]["content"].Type);
+            Assert.Equal(changeRef, parsed["changeReference"].ToString());
+        }
+
+        [Fact]
+        public void Payload_ChangeReferenceNull_StillPresent()
+        {
+            // When user passes only -AcquirePolicyToken without -ChangeReference,
+            // changeReference should be null in the payload (matching CLI)
+            var payload = new
+            {
+                operation = new { uri = "https://management.azure.com/test", httpMethod = "PUT", content = (object)null },
+                changeReference = (string)null
+            };
+
+            var json = JsonConvert.SerializeObject(payload);
+            var parsed = JObject.Parse(json);
+
+            Assert.True(parsed.ContainsKey("changeReference"), "changeReference key must always be present");
+            Assert.Equal(JTokenType.Null, parsed["changeReference"].Type);
+        }
+
+        [Fact]
+        public void Payload_ContainsRequestBody_WhenPresent()
+        {
+            var body = new { name = "testAccount", location = "eastus" };
+            var payload = new
+            {
+                operation = new { uri = "https://management.azure.com/test", httpMethod = "PUT", content = (object)body },
+                changeReference = (string)null
+            };
+
+            var json = JsonConvert.SerializeObject(payload);
+            var parsed = JObject.Parse(json);
+
+            Assert.Equal("testAccount", parsed["operation"]["content"]["name"].ToString());
+            Assert.Equal("eastus", parsed["operation"]["content"]["location"].ToString());
+        }
+
+        [Theory]
+        [InlineData("PUT")]
+        [InlineData("POST")]
+        [InlineData("DELETE")]
+        [InlineData("PATCH")]
+        public void Payload_HttpMethodPreserved(string method)
+        {
+            var payload = new
+            {
+                operation = new { uri = "https://management.azure.com/test", httpMethod = method, content = (object)null },
+                changeReference = (string)null
+            };
+
+            var json = JsonConvert.SerializeObject(payload);
+            var parsed = JObject.Parse(json);
+            Assert.Equal(method, parsed["operation"]["httpMethod"].ToString());
+        }
+    }
+
+    // =========================================================================
+    // 3. SUBSCRIPTION ID EXTRACTION TESTS
+    // =========================================================================
+    public class SubscriptionIdExtractionTests
+    {
+        private static readonly System.Text.RegularExpressions.Regex SubRegex =
+            new System.Text.RegularExpressions.Regex(@"/subscriptions/([0-9a-fA-F-]{36})",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        [Theory]
+        [InlineData("https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg", "00000000-0000-0000-0000-000000000000")]
+        [InlineData("https://eastus2euap.management.azure.com/subscriptions/10b28d5e-a5a6-4274-afac-3a7ef12e3055/providers/Microsoft.Authorization/acquirePolicyToken", "10b28d5e-a5a6-4274-afac-3a7ef12e3055")]
+        [InlineData("https://management.azure.com/subscriptions/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/test", "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")]
+        public void ExtractsSubscriptionId_FromValidUrls(string url, string expected)
+        {
+            var match = SubRegex.Match(new Uri(url).AbsolutePath);
+            Assert.True(match.Success);
+            Assert.Equal(expected, match.Groups[1].Value, StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData("https://management.azure.com/tenants")]
+        [InlineData("https://management.azure.com/providers/Microsoft.Storage")]
+        [InlineData("https://management.azure.com/subscriptions/not-a-guid/test")]
+        public void ReturnsNull_WhenNoSubscriptionId(string url)
+        {
+            var match = SubRegex.Match(new Uri(url).AbsolutePath);
+            Assert.False(match.Success);
+        }
+    }
+
+    // =========================================================================
+    // 4. API VERSION AND CONSTANTS TESTS
+    // =========================================================================
+    public class PolicyTokenConstantsTests
+    {
+        [Fact]
+        public void TokenApiVersion_Matches_2025_03_01()
+        {
+            // Must match Azure CLI and the design spec
+            string subscriptionId = "00000000-0000-0000-0000-000000000000";
+            var path = $"/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/acquirePolicyToken?api-version=2025-03-01";
+            Assert.Contains("api-version=2025-03-01", path);
+            Assert.Contains("Microsoft.Authorization/acquirePolicyToken", path);
+        }
+
+        [Theory]
+        [InlineData("PUT", true)]
+        [InlineData("POST", true)]
+        [InlineData("DELETE", true)]
+        [InlineData("PATCH", true)]
+        [InlineData("GET", false)]
+        [InlineData("HEAD", false)]
+        [InlineData("OPTIONS", false)]
+        [InlineData("TRACE", false)]
+        public void AllowedWriteMethods_MatchDesign(string method, bool shouldBeAllowed)
+        {
+            var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "PUT", "POST", "DELETE", "PATCH" };
+            Assert.Equal(shouldBeAllowed, allowed.Contains(method));
+        }
+
+        [Fact]
+        public void PolicyTokenHeader_NameMatchesSpec()
+        {
+            // Header name must be exactly this — ARM checks for it
+            Assert.Equal("x-ms-policy-external-evaluations", "x-ms-policy-external-evaluations");
+        }
+    }
+
+    // =========================================================================
+    // 5. REGRESSION SAFETY TESTS — Ensure no impact when params not used
+    // =========================================================================
+    public class RegressionSafetyTests
+    {
+        [Fact]
+        public async Task NoRegression_DeleteRequest_WithoutFlag_GoesThrough()
+        {
+            bool innerCalled = false;
+            var innerHandler = new MockInnerHandler((req, ct) =>
+            {
+                innerCalled = true;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"id\":\"test\"}", Encoding.UTF8, "application/json")
+                });
+            });
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+
+            var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
+                "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa?api-version=2024-01-01"));
+
+            Assert.True(innerCalled);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var content = await response.Content.ReadAsStringAsync();
+            Assert.Contains("test", content);
+        }
+
+        [Fact]
+        public async Task NoRegression_PutRequest_WithBody_WithoutFlag_GoesThrough()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var innerHandler = new MockInnerHandler((req, ct) =>
+            {
+                capturedRequest = req;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created));
+            });
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+
+            var request = new HttpRequestMessage(HttpMethod.Put,
+                "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa?api-version=2024-01-01")
+            {
+                Content = new StringContent("{\"location\":\"eastus\"}", Encoding.UTF8, "application/json")
+            };
+
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+            Assert.NotNull(capturedRequest.Content);
+            Assert.False(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"));
+        }
+
+        [Fact]
+        public async Task NoRegression_PatchRequest_WithoutFlag_GoesThrough()
+        {
+            var innerHandler = new MockInnerHandler((req, ct) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+
+            var response = await client.SendAsync(new HttpRequestMessage(new HttpMethod("PATCH"),
+                "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/test"));
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task NoRegression_MultipleRequests_NoneGetToken()
+        {
+            int callCount = 0;
+            var innerHandler = new MockInnerHandler((req, ct) =>
+            {
+                callCount++;
+                Assert.False(req.Headers.Contains("x-ms-policy-external-evaluations"),
+                    $"Request #{callCount} should not have the token header.");
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+
+            var baseUrl = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/";
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, baseUrl + "list"));
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Put, baseUrl + "create"));
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, baseUrl + "delete"));
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Post, baseUrl + "action"));
+
+            Assert.Equal(4, callCount);
+        }
+
+        [Fact]
+        public async Task NoRegression_CustomHeaders_Preserved()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var innerHandler = new MockInnerHandler((req, ct) =>
+            {
+                capturedRequest = req;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+
+            var request = new HttpRequestMessage(HttpMethod.Put,
+                "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/test");
+            request.Headers.Add("x-custom-header", "my-value");
+            request.Headers.Add("x-ms-client-request-id", "test-id-123");
+
+            await client.SendAsync(request);
+
+            Assert.True(capturedRequest.Headers.Contains("x-custom-header"));
+            Assert.True(capturedRequest.Headers.Contains("x-ms-client-request-id"));
+            Assert.Equal("my-value", capturedRequest.Headers.GetValues("x-custom-header").First());
+        }
+
+        [Fact]
+        public async Task NoRegression_ResponsePassedThrough_Unmodified()
+        {
+            var expectedBody = "{\"status\":\"success\",\"id\":\"12345\"}";
+            var innerHandler = new MockInnerHandler((req, ct) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(expectedBody, Encoding.UTF8, "application/json"),
+                    ReasonPhrase = "OK"
+                }));
+
+            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+
+            var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
+                "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/test"));
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.Equal(expectedBody, body);
+        }
+    }
+
+    // =========================================================================
+    // 6. DYNAMIC PARAMETER FILTERING TESTS — Get/List/Show exclusion
+    // =========================================================================
+    public class DynamicParameterFilteringTests
+    {
+        /// <summary>
+        /// Verifies the cmdlet name filtering logic used in GetDynamicParameters.
+        /// Write cmdlets should get parameters, read cmdlets should not.
+        /// </summary>
+        [Theory]
+        [InlineData("New-AzStorageAccount", true)]
+        [InlineData("Set-AzStorageAccount", true)]
+        [InlineData("Remove-AzStorageAccount", true)]
+        [InlineData("Add-AzIotHubDevice", true)]
+        [InlineData("Update-AzVM", true)]
+        [InlineData("Invoke-AzResourceAction", true)]
+        [InlineData("Start-AzVM", true)]
+        [InlineData("Stop-AzVM", true)]
+        [InlineData("Restart-AzVM", true)]
+        [InlineData("Get-AzStorageAccount", false)]
+        [InlineData("Get-AzVM", false)]
+        [InlineData("Get-AzContext", false)]
+        [InlineData("Get-AzSubscription", false)]
+        public void WriteCmdlets_GetParams_ReadCmdlets_DoNot(string commandName, bool shouldHaveParams)
+        {
+            bool isReadOnly = commandName.StartsWith("Get", StringComparison.OrdinalIgnoreCase)
+                || commandName.EndsWith("List", StringComparison.OrdinalIgnoreCase)
+                || commandName.EndsWith("Show", StringComparison.OrdinalIgnoreCase);
+
+            Assert.Equal(shouldHaveParams, !isReadOnly);
+        }
+
+        [Theory]
+        [InlineData("Get-AzResourceList", false)]  // ends in "List"
+        [InlineData("Get-AzVMShow", false)]         // ends in "Show"
+        [InlineData("Export-AzStorageData", true)]   // Export is a write operation
+        [InlineData("Import-AzData", true)]          // Import is a write operation
+        [InlineData("Disable-AzFeature", true)]
+        [InlineData("Enable-AzFeature", true)]
+        public void EdgeCases_FilteredCorrectly(string commandName, bool shouldHaveParams)
+        {
+            bool isReadOnly = commandName.StartsWith("Get", StringComparison.OrdinalIgnoreCase)
+                || commandName.EndsWith("List", StringComparison.OrdinalIgnoreCase)
+                || commandName.EndsWith("Show", StringComparison.OrdinalIgnoreCase);
+
+            Assert.Equal(shouldHaveParams, !isReadOnly);
+        }
+    }
+
+    // =========================================================================
+    // 7. CHANGE REFERENCE VALIDATION TESTS
+    // =========================================================================
+    public class ChangeReferenceValidationTests
+    {
+        [Fact]
+        public void ValidChangeReference_IsStageProgressionPath()
+        {
+            // A valid change reference looks like:
+            // /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ChangeSafety/changeStates/{name}/stageProgressions/{stage}
+            string changeRef = "/subscriptions/10b28d5e-a5a6-4274-afac-3a7ef12e3055/resourceGroups/myRG/providers/Microsoft.ChangeSafety/changeStates/myChange/stageProgressions/breakglassStage";
+
+            Assert.Contains("Microsoft.ChangeSafety", changeRef);
+            Assert.Contains("changeStates", changeRef);
+            Assert.Contains("stageProgressions", changeRef);
+        }
+
+        [Fact]
+        public void EmptyChangeReference_NotTreatedAsPresent()
+        {
+            // Empty string should not trigger token acquisition
+            string changeRef = "";
+            Assert.True(string.IsNullOrEmpty(changeRef));
+        }
+
+        [Fact]
+        public void NullChangeReference_NotTreatedAsPresent()
+        {
+            string changeRef = null;
+            Assert.True(string.IsNullOrEmpty(changeRef));
+        }
+    }
+
+    // =========================================================================
+    // 8. HEADER SANITIZATION TESTS — Ensure token is in AuthorizationHeaderNames
+    // =========================================================================
+    public class HeaderSanitizationTests
+    {
+        [Fact]
+        public void PolicyTokenHeader_IsInAuthorizationHeaderNames()
+        {
+            // GeneralUtilities.AuthorizationHeaderNames must include the policy token header
+            // to prevent it from being logged in traces
+            var authHeaders = new List<string> { "Authorization", "x-ms-policy-external-evaluations" };
+            Assert.Contains("x-ms-policy-external-evaluations", authHeaders);
+        }
+    }
+
+    // =========================================================================
+    // MOCK INNER HANDLER — Shared test infrastructure
+    // =========================================================================
+    internal class MockInnerHandler : DelegatingHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handlerFunc;
+
+        public MockInnerHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handlerFunc)
+        {
+            _handlerFunc = handlerFunc;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _handlerFunc(request, cancellationToken);
+        }
+    }
+}
+

--- a/src/Common.Test/AcquirePolicyTokenHandlerTests.cs
+++ b/src/Common.Test/AcquirePolicyTokenHandlerTests.cs
@@ -308,8 +308,11 @@ namespace Commands.Common.Tests
         [Fact]
         public void PolicyTokenHeader_NameMatchesSpec()
         {
-            // Header name must be exactly this — ARM checks for it
-            Assert.Equal("x-ms-policy-external-evaluations", "x-ms-policy-external-evaluations");
+            // Verify the header name is recognized by HTTP headers (case-insensitive)
+            var request = new HttpRequestMessage();
+            request.Headers.Add("x-ms-policy-external-evaluations", "test-token");
+            Assert.True(request.Headers.Contains("x-ms-policy-external-evaluations"));
+            Assert.Equal("test-token", request.Headers.GetValues("x-ms-policy-external-evaluations").First());
         }
     }
 
@@ -479,18 +482,21 @@ namespace Commands.Common.Tests
         [InlineData("Get-AzVM", false)]
         [InlineData("Get-AzContext", false)]
         [InlineData("Get-AzSubscription", false)]
+        [InlineData("Test-AzDeployment", false)]
+        [InlineData("Test-AzResourceGroupDeployment", false)]
         public void WriteCmdlets_GetParams_ReadCmdlets_DoNot(string commandName, bool shouldHaveParams)
         {
             bool isReadOnly = commandName.StartsWith("Get", StringComparison.OrdinalIgnoreCase)
-                || commandName.EndsWith("List", StringComparison.OrdinalIgnoreCase)
-                || commandName.EndsWith("Show", StringComparison.OrdinalIgnoreCase);
+                || commandName.StartsWith("Test", StringComparison.OrdinalIgnoreCase)
+                || commandName.StartsWith("List", StringComparison.OrdinalIgnoreCase)
+                || commandName.StartsWith("Show", StringComparison.OrdinalIgnoreCase);
 
             Assert.Equal(shouldHaveParams, !isReadOnly);
         }
 
         [Theory]
-        [InlineData("Get-AzResourceList", false)]  // ends in "List"
-        [InlineData("Get-AzVMShow", false)]         // ends in "Show"
+        [InlineData("List-AzResource", false)]      // starts with "List"
+        [InlineData("Show-AzVM", false)]             // starts with "Show"
         [InlineData("Export-AzStorageData", true)]   // Export is a write operation
         [InlineData("Import-AzData", true)]          // Import is a write operation
         [InlineData("Disable-AzFeature", true)]
@@ -498,8 +504,9 @@ namespace Commands.Common.Tests
         public void EdgeCases_FilteredCorrectly(string commandName, bool shouldHaveParams)
         {
             bool isReadOnly = commandName.StartsWith("Get", StringComparison.OrdinalIgnoreCase)
-                || commandName.EndsWith("List", StringComparison.OrdinalIgnoreCase)
-                || commandName.EndsWith("Show", StringComparison.OrdinalIgnoreCase);
+                || commandName.StartsWith("Test", StringComparison.OrdinalIgnoreCase)
+                || commandName.StartsWith("List", StringComparison.OrdinalIgnoreCase)
+                || commandName.StartsWith("Show", StringComparison.OrdinalIgnoreCase);
 
             Assert.Equal(shouldHaveParams, !isReadOnly);
         }

--- a/src/Common.Test/AcquirePolicyTokenHandlerTests.cs
+++ b/src/Common.Test/AcquirePolicyTokenHandlerTests.cs
@@ -13,7 +13,6 @@
 // ----------------------------------------------------------------------------------
 
 using Microsoft.WindowsAzure.Commands.Common;
-using Microsoft.WindowsAzure.Commands.Utilities.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -39,7 +38,7 @@ namespace Commands.Common.Tests
         [Fact]
         public void Clone_ReturnsNewInstance()
         {
-            var handler = new AcquirePolicyTokenHandler(null);
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null);
             var clone = handler.Clone() as AcquirePolicyTokenHandler;
 
             Assert.NotNull(clone);
@@ -56,7 +55,7 @@ namespace Commands.Common.Tests
             var innerHandler = new MockInnerHandler((req, ct) =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
             var request = new HttpRequestMessage(HttpMethod.Get,
                 "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa?api-version=2024-01-01");
@@ -74,7 +73,7 @@ namespace Commands.Common.Tests
             var innerHandler = new MockInnerHandler((req, ct) =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
             var request = new HttpRequestMessage(HttpMethod.Head,
                 "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/test");
@@ -98,7 +97,7 @@ namespace Commands.Common.Tests
             var innerHandler = new MockInnerHandler((req, ct) =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
             var request = new HttpRequestMessage(new HttpMethod(method),
                 "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa?api-version=2024-01-01");
@@ -124,7 +123,7 @@ namespace Commands.Common.Tests
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
 
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
@@ -143,7 +142,7 @@ namespace Commands.Common.Tests
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
             var uri = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/test?api-version=2024-01-01";
             var request = new HttpRequestMessage(HttpMethod.Put, uri);
@@ -332,7 +331,7 @@ namespace Commands.Common.Tests
                 });
             });
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
 
             var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
@@ -354,7 +353,7 @@ namespace Commands.Common.Tests
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Created));
             });
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
 
             var request = new HttpRequestMessage(HttpMethod.Put,
@@ -376,7 +375,7 @@ namespace Commands.Common.Tests
             var innerHandler = new MockInnerHandler((req, ct) =>
                 Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
 
             var response = await client.SendAsync(new HttpRequestMessage(new HttpMethod("PATCH"),
@@ -397,7 +396,7 @@ namespace Commands.Common.Tests
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
 
             var baseUrl = "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/";
@@ -419,7 +418,7 @@ namespace Commands.Common.Tests
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
             });
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
 
             var request = new HttpRequestMessage(HttpMethod.Put,
@@ -445,7 +444,7 @@ namespace Commands.Common.Tests
                     ReasonPhrase = "OK"
                 }));
 
-            var handler = new AcquirePolicyTokenHandler(null) { InnerHandler = innerHandler };
+            var handler = new AcquirePolicyTokenHandler(false, null, false, null) { InnerHandler = innerHandler };
             var client = new HttpClient(handler);
 
             var response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
@@ -555,13 +554,428 @@ namespace Commands.Common.Tests
     }
 
     // =========================================================================
-    // MOCK INNER HANDLER — Shared test infrastructure
+    // 9. END-TO-END FLOW TESTS — Full token acquisition pipeline
+    //    Simulates: handler → acquirePolicyToken API → token → header → request
+    // =========================================================================
+    public class EndToEndPolicyTokenFlowTests
+    {
+        private const string TestToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-policy-token-value";
+        private const string TestSubId = "f5d0e517-47aa-467c-90a0-4326d3c0fcae";
+        private const string BaseUrl = "https://management.azure.com";
+
+        /// <summary>
+        /// Creates a mock token server that returns a valid token response.
+        /// </summary>
+        private static HttpClient CreateMockTokenServer(Action<HttpRequestMessage> captureTokenRequest = null)
+        {
+            var handler = new MockTokenServerHandler((req, ct) =>
+            {
+                captureTokenRequest?.Invoke(req);
+                var responseBody = JsonConvert.SerializeObject(new { token = TestToken });
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+                });
+            });
+            return new HttpClient(handler);
+        }
+
+        /// <summary>
+        /// Creates a mock token server that returns a failure.
+        /// </summary>
+        private static HttpClient CreateFailingTokenServer(HttpStatusCode statusCode, string errorMessage)
+        {
+            var handler = new MockTokenServerHandler((req, ct) =>
+            {
+                var body = JsonConvert.SerializeObject(new { error = new { code = "TestError", message = errorMessage } });
+                return Task.FromResult(new HttpResponseMessage(statusCode)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json")
+                });
+            });
+            return new HttpClient(handler);
+        }
+
+        /// <summary>
+        /// Creates the handler with a mock cmdlet that has ShouldAcquirePolicyToken = true.
+        /// Uses internal constructor to inject a mock token HTTP client.
+        /// </summary>
+        private static (AcquirePolicyTokenHandler handler, HttpClient client) CreateTestPipeline(
+            HttpClient tokenHttpClient,
+            Action<HttpRequestMessage> captureRequest = null)
+        {
+            var innerHandler = new MockInnerHandler((req, ct) =>
+            {
+                captureRequest?.Invoke(req);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+            var handler = new AcquirePolicyTokenHandler(true, null, false, new ConcurrentQueue<string>(), tokenHttpClient)
+            {
+                InnerHandler = innerHandler
+            };
+
+            return (handler, new HttpClient(handler));
+        }
+
+        // ----- DELETE Storage Account -----
+
+        [Fact]
+        public async Task E2E_DeleteStorageAccount_TokenAcquired_HeaderAttached()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var tokenClient = CreateMockTokenServer();
+            var (handler, client) = CreateTestPipeline(tokenClient, req => capturedRequest = req);
+
+            var request = new HttpRequestMessage(HttpMethod.Delete,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/testsa?api-version=2024-01-01");
+
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"),
+                "DELETE Storage Account: policy token header must be present");
+            Assert.Equal(TestToken,
+                capturedRequest.Headers.GetValues("x-ms-policy-external-evaluations").First());
+        }
+
+        // ----- DELETE Resource Group -----
+
+        [Fact]
+        public async Task E2E_DeleteResourceGroup_TokenAcquired_HeaderAttached()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var tokenClient = CreateMockTokenServer();
+            var (handler, client) = CreateTestPipeline(tokenClient, req => capturedRequest = req);
+
+            var request = new HttpRequestMessage(HttpMethod.Delete,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/test-rg?api-version=2021-04-01");
+
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"));
+            Assert.Equal(TestToken,
+                capturedRequest.Headers.GetValues("x-ms-policy-external-evaluations").First());
+        }
+
+        // ----- PUT (Create/Update) VM -----
+
+        [Fact]
+        public async Task E2E_PutVM_TokenAcquired_HeaderAttached()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var tokenClient = CreateMockTokenServer();
+            var (handler, client) = CreateTestPipeline(tokenClient, req => capturedRequest = req);
+
+            var request = new HttpRequestMessage(HttpMethod.Put,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/testvm?api-version=2024-03-01")
+            {
+                Content = new StringContent("{\"location\":\"eastus\"}", Encoding.UTF8, "application/json")
+            };
+
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"));
+            Assert.Equal(TestToken,
+                capturedRequest.Headers.GetValues("x-ms-policy-external-evaluations").First());
+        }
+
+        // ----- POST Action (e.g., restart VM) -----
+
+        [Fact]
+        public async Task E2E_PostVMRestart_TokenAcquired_HeaderAttached()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var tokenClient = CreateMockTokenServer();
+            var (handler, client) = CreateTestPipeline(tokenClient, req => capturedRequest = req);
+
+            var request = new HttpRequestMessage(HttpMethod.Post,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/testvm/restart?api-version=2024-03-01");
+
+            var response = await client.SendAsync(request);
+
+            Assert.True(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"));
+            Assert.Equal(TestToken,
+                capturedRequest.Headers.GetValues("x-ms-policy-external-evaluations").First());
+        }
+
+        // ----- PATCH (Update) Network Security Group -----
+
+        [Fact]
+        public async Task E2E_PatchNSG_TokenAcquired_HeaderAttached()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var tokenClient = CreateMockTokenServer();
+            var (handler, client) = CreateTestPipeline(tokenClient, req => capturedRequest = req);
+
+            var request = new HttpRequestMessage(new HttpMethod("PATCH"),
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Network/networkSecurityGroups/testnsg?api-version=2023-11-01")
+            {
+                Content = new StringContent("{\"tags\":{\"env\":\"test\"}}", Encoding.UTF8, "application/json")
+            };
+
+            var response = await client.SendAsync(request);
+
+            Assert.True(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"));
+            Assert.Equal(TestToken,
+                capturedRequest.Headers.GetValues("x-ms-policy-external-evaluations").First());
+        }
+
+        // ----- DELETE CosmosDB Account -----
+
+        [Fact]
+        public async Task E2E_DeleteCosmosDBAccount_TokenAcquired_HeaderAttached()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var tokenClient = CreateMockTokenServer();
+            var (handler, client) = CreateTestPipeline(tokenClient, req => capturedRequest = req);
+
+            var request = new HttpRequestMessage(HttpMethod.Delete,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.DocumentDB/databaseAccounts/testcosmos?api-version=2024-05-15");
+
+            var response = await client.SendAsync(request);
+
+            Assert.True(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"));
+            Assert.Equal(TestToken,
+                capturedRequest.Headers.GetValues("x-ms-policy-external-evaluations").First());
+        }
+
+        // ----- DELETE Key Vault -----
+
+        [Fact]
+        public async Task E2E_DeleteKeyVault_TokenAcquired_HeaderAttached()
+        {
+            HttpRequestMessage capturedRequest = null;
+            var tokenClient = CreateMockTokenServer();
+            var (handler, client) = CreateTestPipeline(tokenClient, req => capturedRequest = req);
+
+            var request = new HttpRequestMessage(HttpMethod.Delete,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/testvault?api-version=2023-07-01");
+
+            var response = await client.SendAsync(request);
+
+            Assert.True(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"));
+            Assert.Equal(TestToken,
+                capturedRequest.Headers.GetValues("x-ms-policy-external-evaluations").First());
+        }
+
+        // ----- Verify token API request payload -----
+
+        [Fact]
+        public async Task E2E_TokenRequest_ContainsCorrectPayload()
+        {
+            HttpRequestMessage capturedTokenRequest = null;
+            var tokenClient = CreateMockTokenServer(req => capturedTokenRequest = req);
+            var (handler, client) = CreateTestPipeline(tokenClient);
+
+            var deleteUri = $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1?api-version=2024-01-01";
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, deleteUri));
+
+            // Verify the token request
+            Assert.NotNull(capturedTokenRequest);
+            Assert.Equal(HttpMethod.Post, capturedTokenRequest.Method);
+            Assert.Contains("acquirePolicyToken", capturedTokenRequest.RequestUri.ToString());
+            Assert.Contains(TestSubId, capturedTokenRequest.RequestUri.ToString());
+            Assert.Contains("api-version=2025-03-01", capturedTokenRequest.RequestUri.ToString());
+
+            // Verify payload
+            var body = await capturedTokenRequest.Content.ReadAsStringAsync();
+            var payload = JObject.Parse(body);
+            Assert.Equal(deleteUri, payload["operation"]["uri"].ToString());
+            Assert.Equal("DELETE", payload["operation"]["httpMethod"].ToString());
+
+            // Verify x-ms-force-sync header
+            Assert.True(capturedTokenRequest.Headers.Contains("x-ms-force-sync"));
+        }
+
+        // ----- Verify changeReference is passed in payload -----
+
+        [Fact]
+        public async Task E2E_TokenRequest_IncludesChangeReference()
+        {
+            HttpRequestMessage capturedTokenRequest = null;
+            var tokenClient = CreateMockTokenServer(req => capturedTokenRequest = req);
+
+            string changeRef = $"/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.ChangeSafety/changeStates/cs/stageProgressions/breakglassStage";
+            var innerHandler = new MockInnerHandler((req, ct) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+
+            var handler = new AcquirePolicyTokenHandler(true, changeRef, false, new ConcurrentQueue<string>(), tokenClient) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1?api-version=2024-01-01"));
+
+            var body = await capturedTokenRequest.Content.ReadAsStringAsync();
+            var payload = JObject.Parse(body);
+            Assert.Equal(changeRef, payload["changeReference"].ToString());
+        }
+
+        // ----- Verify auth headers are forwarded to token request -----
+
+        [Fact]
+        public async Task E2E_TokenRequest_ForwardsAuthHeaders()
+        {
+            HttpRequestMessage capturedTokenRequest = null;
+            var tokenClient = CreateMockTokenServer(req => capturedTokenRequest = req);
+            var (handler, client) = CreateTestPipeline(tokenClient);
+
+            var request = new HttpRequestMessage(HttpMethod.Delete,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1?api-version=2024-01-01");
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "test-token-123");
+            request.Headers.Add("x-ms-authorization-auxiliary", "Bearer aux-token-456");
+
+            await client.SendAsync(request);
+
+            Assert.Equal("Bearer", capturedTokenRequest.Headers.Authorization.Scheme);
+            Assert.Equal("test-token-123", capturedTokenRequest.Headers.Authorization.Parameter);
+            Assert.True(capturedTokenRequest.Headers.Contains("x-ms-authorization-auxiliary"));
+        }
+
+        // ----- Token API failure returns clear error -----
+
+        [Fact]
+        public async Task E2E_TokenApiFails_ThrowsWithMessage()
+        {
+            var tokenClient = CreateFailingTokenServer(HttpStatusCode.Forbidden, "Access denied");
+            var (handler, client) = CreateTestPipeline(tokenClient);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
+                    $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1?api-version=2024-01-01")));
+
+            Assert.Contains("Failed to acquire policy token", ex.Message);
+            Assert.Contains("403", ex.Message);
+        }
+
+        // ----- Token API returns 200 but no token field -----
+
+        [Fact]
+        public async Task E2E_TokenApiReturns200ButNoToken_ThrowsWithResponse()
+        {
+            var handler = new MockTokenServerHandler((req, ct) =>
+            {
+                var body = JsonConvert.SerializeObject(new { result = "Failed", message = "validator error" });
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json")
+                });
+            });
+            var tokenClient = new HttpClient(handler);
+            var (pipelineHandler, client) = CreateTestPipeline(tokenClient);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
+                    $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1?api-version=2024-01-01")));
+
+            Assert.Contains("No token returned", ex.Message);
+            Assert.Contains("validator error", ex.Message);
+        }
+
+        // ----- GET request is NOT intercepted even with flag -----
+
+        [Fact]
+        public async Task E2E_GetRequest_NeverAcquiresToken_EvenWithFlag()
+        {
+            bool tokenServerCalled = false;
+            var tokenClient = CreateMockTokenServer(_ => tokenServerCalled = true);
+            HttpRequestMessage capturedRequest = null;
+            var (handler, client) = CreateTestPipeline(tokenClient, req => capturedRequest = req);
+
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Get,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1?api-version=2024-01-01"));
+
+            Assert.False(tokenServerCalled, "Token API must NOT be called for GET requests");
+            Assert.False(capturedRequest.Headers.Contains("x-ms-policy-external-evaluations"));
+        }
+
+        // ----- Multiple sequential requests each get their own token -----
+
+        [Fact]
+        public async Task E2E_MultipleRequests_EachGetsToken()
+        {
+            int tokenCallCount = 0;
+            var mockHandler = new MockTokenServerHandler((req, ct) =>
+            {
+                Interlocked.Increment(ref tokenCallCount);
+                var body = JsonConvert.SerializeObject(new { token = $"token-{tokenCallCount}" });
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json")
+                });
+            });
+            var tokenClient = new HttpClient(mockHandler);
+
+            List<string> capturedTokens = new List<string>();
+            var innerHandler = new MockInnerHandler((req, ct) =>
+            {
+                if (req.Headers.Contains("x-ms-policy-external-evaluations"))
+                    capturedTokens.Add(req.Headers.GetValues("x-ms-policy-external-evaluations").First());
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            });
+
+            var handler = new AcquirePolicyTokenHandler(true, null, false, new ConcurrentQueue<string>(), tokenClient) { InnerHandler = innerHandler };
+            var client = new HttpClient(handler);
+
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/sa1?api-version=2024-01-01"));
+            await client.SendAsync(new HttpRequestMessage(HttpMethod.Put,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg2/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2024-03-01"));
+
+            Assert.Equal(2, tokenCallCount);
+            Assert.Equal(2, capturedTokens.Count);
+        }
+
+        // ----- Request body is included in token payload -----
+
+        [Fact]
+        public async Task E2E_PutWithBody_BodyIncludedInTokenPayload()
+        {
+            HttpRequestMessage capturedTokenRequest = null;
+            var tokenClient = CreateMockTokenServer(req => capturedTokenRequest = req);
+            var (handler, client) = CreateTestPipeline(tokenClient);
+
+            var requestBody = "{\"location\":\"eastus\",\"sku\":{\"name\":\"Standard_GRS\"}}";
+            var request = new HttpRequestMessage(HttpMethod.Put,
+                $"{BaseUrl}/subscriptions/{TestSubId}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/sa1?api-version=2024-01-01")
+            {
+                Content = new StringContent(requestBody, Encoding.UTF8, "application/json")
+            };
+
+            await client.SendAsync(request);
+
+            var tokenBody = await capturedTokenRequest.Content.ReadAsStringAsync();
+            var payload = JObject.Parse(tokenBody);
+            Assert.Equal("eastus", payload["operation"]["content"]["location"].ToString());
+            Assert.Equal("Standard_GRS", payload["operation"]["content"]["sku"]["name"].ToString());
+        }
+    }
+
+    // =========================================================================
+    // MOCK HANDLERS — Shared test infrastructure
     // =========================================================================
     internal class MockInnerHandler : DelegatingHandler
     {
         private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handlerFunc;
 
         public MockInnerHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handlerFunc)
+        {
+            _handlerFunc = handlerFunc;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _handlerFunc(request, cancellationToken);
+        }
+    }
+
+    internal class MockTokenServerHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handlerFunc;
+
+        public MockTokenServerHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handlerFunc)
         {
             _handlerFunc = handlerFunc;
         }

--- a/src/Common.Test/Common.Test.csproj
+++ b/src/Common.Test/Common.Test.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />
+    <ProjectReference Include="..\Authentication.Abstractions\Authentication.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common.Test/Common.Test.csproj
+++ b/src/Common.Test/Common.Test.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(ProjectDir)..\Dependencies.Test.targets" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>Microsoft.Azure.PowerShell.Common.Test</AssemblyName>
+    <OutputPath>$(ProjectDir)..\..\artifacts\$(Configuration)</OutputPath>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE;RELEASE;NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+    <EmbeddedResource Remove="Properties\AssemblyInfo.cs" />
+    <None Remove="Properties\AssemblyInfo.cs" />
+    <Content Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Common/AcquirePolicyTokenHandler.cs
+++ b/src/Common/AcquirePolicyTokenHandler.cs
@@ -1,0 +1,234 @@
+// ----------------------------------------------------------------------------------
+//
+// Copyright Microsoft Corporation
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Net;
+using Microsoft.WindowsAzure.Commands.Utilities.Common;
+
+namespace Microsoft.WindowsAzure.Commands.Common
+{
+    /// <summary>
+    /// Delegating handler to acquire an Azure Policy token for change safety feature and attach to outgoing request.
+    /// Activated when user specifies -AcquirePolicyToken. (ChangeReference deferred to Phase 2.)
+    /// </summary>
+    public class AcquirePolicyTokenHandler : DelegatingHandler, ICloneable
+    {
+        private readonly AzurePSCmdlet _cmdlet;
+        private const string TokenApiVersion = "2025-03-01";
+        private static readonly Regex SubscriptionIdRegex = new Regex(@"/subscriptions/([0-9a-fA-F-]{36})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly HashSet<string> _allowedWriteMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            HttpMethod.Put.Method,
+            HttpMethod.Post.Method,
+            HttpMethod.Delete.Method,
+            "PATCH"
+        };
+        private const string LogPrefix = "[AcquirePolicyTokenHandler]";
+
+        public AcquirePolicyTokenHandler(AzurePSCmdlet cmdlet)
+        {
+            _cmdlet = cmdlet;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            EnqueueDebug($"Intercept {request.Method} {request.RequestUri}");
+
+            if (!(_cmdlet?.IsPolicyTokenFeatureEnabled() ?? false))
+            {
+                EnqueueDebug("Skip: feature disabled (EnableAcquirePolicyToken config set to false).");
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+
+            bool allowedVerb = _allowedWriteMethods.Contains(request.Method.Method);
+            if (!allowedVerb)
+            {
+                EnqueueDebug("Skip: verb not allowed for token acquisition.");
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+
+            bool hasCmdlet = _cmdlet != null;
+            bool userRequested = hasCmdlet && _cmdlet.ShouldAcquirePolicyToken;
+            if (!userRequested)
+            {
+                EnqueueDebug("Skip: user did not request token (no -AcquirePolicyToken).");
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+
+            var isWhatIf = _cmdlet.MyInvocation?.BoundParameters?.ContainsKey("WhatIf") == true;
+            if (isWhatIf)
+            {
+                EnqueueDebug("Skip: -WhatIf present (dry run).");
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+
+            try
+            {
+                var token = await AcquirePolicyTokenAsync(request, cancellationToken).ConfigureAwait(false);
+                
+                //Debug token, as is
+                // EnqueueDebug($"Token: {token}");
+                
+                
+                if (!string.IsNullOrEmpty(token))
+                {
+                    if (request.Headers.Contains("x-ms-policy-external-evaluations"))
+                    {
+                        request.Headers.Remove("x-ms-policy-external-evaluations");
+                    }
+                    request.Headers.Add("x-ms-policy-external-evaluations", token);
+                    EnqueueDebug("Token acquired and header added.");
+                }
+                else
+                {
+                    EnqueueDebug("No token returned (null/empty).");
+                }
+            }
+            catch (Exception ex)
+            {
+                EnqueueDebug($"Exception: {ex.GetType().Name}: {ex.Message}");
+                throw new InvalidOperationException($"Failed to acquire policy token: {ex.Message}", ex);
+            }
+
+            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<string> AcquirePolicyTokenAsync(HttpRequestMessage originalRequest, CancellationToken cancellationToken)
+        {
+            var subscriptionId = ExtractSubscriptionId(originalRequest.RequestUri);
+            if (string.IsNullOrEmpty(subscriptionId))
+            {
+                EnqueueDebug("Failed: subscription id not found in URI.");
+                throw new InvalidOperationException("Unable to determine subscription ID for policy token acquisition.");
+            }
+
+            var authority = originalRequest.RequestUri.GetLeftPart(UriPartial.Authority);
+            var relativePath = $"/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/acquirePolicyToken?api-version={TokenApiVersion}";
+            var tokenUri = new Uri(authority + relativePath);
+
+            object contentObj = null;
+            if (originalRequest.Content != null)
+            {
+                var body = await originalRequest.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(body))
+                {
+                    try
+                    {
+                        contentObj = JsonConvert.DeserializeObject(body);
+                    }
+                    catch
+                    {
+                        contentObj = body; // leave as raw string if not JSON
+                    }
+                }
+            }
+
+            var payload = new
+            {
+                operation = new
+                {
+                    uri = originalRequest.RequestUri.ToString(),
+                    httpMethod = originalRequest.Method.Method,
+                    content = contentObj
+                }
+                // Phase 2: reintroduce when ChangeReference parameter is enabled
+                // ,changeReference = _cmdlet?.CurrentChangeReference
+            };
+            EnqueueDebug("Payload prepared.");
+
+            var payloadJson = JsonConvert.SerializeObject(payload);
+            var tokenRequest = new HttpRequestMessage(HttpMethod.Post, tokenUri)
+            {
+                Content = new StringContent(payloadJson, Encoding.UTF8, "application/json")
+            };
+            tokenRequest.Headers.Add("x-ms-force-sync", "true");
+
+            // Forward auth headers if present (minimal parity with original request auth context)
+            if (originalRequest.Headers.Authorization != null)
+            {
+                tokenRequest.Headers.Authorization = originalRequest.Headers.Authorization;
+            }
+            if (originalRequest.Headers.TryGetValues("x-ms-authorization-auxiliary", out var auxValues))
+            {
+                tokenRequest.Headers.TryAddWithoutValidation("x-ms-authorization-auxiliary", auxValues);
+            }
+
+            using (var http = new HttpClient())
+            {
+                EnqueueDebug($"POST acquirePolicyToken {tokenUri}");
+                var response = await http.SendAsync(tokenRequest, cancellationToken).ConfigureAwait(false);
+                EnqueueDebug($"Response {(int)response.StatusCode} {response.StatusCode}");
+                var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    if (!string.IsNullOrWhiteSpace(responseContent))
+                    {
+                        var obj = JsonConvert.DeserializeObject<JObject>(responseContent);
+                        var token = obj?["token"]?.ToString();
+                        if (string.IsNullOrEmpty(token))
+                        {
+                            EnqueueDebug("Response OK but token missing.");
+                            throw new InvalidOperationException($"No token returned. Response:{responseContent}");
+                        }
+                        return token;
+                    }
+                    throw new InvalidOperationException("Empty response body when acquiring policy token.");
+                }
+                else if (response.StatusCode == HttpStatusCode.Accepted)
+                {
+                    EnqueueDebug("202 Accepted received (async not supported)." );
+                    throw new InvalidOperationException("Asynchronous policy token acquisition (202 Accepted) is not supported.");
+                }
+                else
+                {
+                    EnqueueDebug("Non-success status; will throw.");
+                    throw new InvalidOperationException($"Policy token acquisition failed with {(int)response.StatusCode} {response.StatusCode}: {responseContent}");
+                }
+            }
+        }
+
+        private static string ExtractSubscriptionId(Uri uri)
+        {
+            if (uri == null) return null;
+            var match = SubscriptionIdRegex.Match(uri.AbsolutePath);
+            if (match.Success && match.Groups.Count > 1)
+            {
+                return match.Groups[1].Value;
+            }
+            return null;
+        }
+
+        public object Clone()
+        {
+            return new AcquirePolicyTokenHandler(_cmdlet);
+        }
+
+        private void EnqueueDebug(string message)
+        {
+            try
+            {
+                _cmdlet?.DebugMessages?.Enqueue($"{LogPrefix} {message}");
+            }
+            catch { }
+        }
+    }
+}

--- a/src/Common/AcquirePolicyTokenHandler.cs
+++ b/src/Common/AcquirePolicyTokenHandler.cs
@@ -137,6 +137,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             object contentObj = null;
             if (originalRequest.Content != null)
             {
+                await originalRequest.Content.LoadIntoBufferAsync().ConfigureAwait(false);
                 var body = await originalRequest.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (!string.IsNullOrWhiteSpace(body))
                 {

--- a/src/Common/AcquirePolicyTokenHandler.cs
+++ b/src/Common/AcquirePolicyTokenHandler.cs
@@ -13,26 +13,32 @@
 // ----------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.Net;
-using Microsoft.WindowsAzure.Commands.Utilities.Common;
 
 namespace Microsoft.WindowsAzure.Commands.Common
 {
     /// <summary>
-    /// Delegating handler to acquire an Azure Policy token for change safety feature and attach to outgoing request.
-    /// Activated when user specifies -AcquirePolicyToken. (ChangeReference deferred to Phase 2.)
+    /// Delegating handler to acquire an Azure Policy token for the change safety feature
+    /// and attach it to outgoing write requests.
+    /// Activated when user specifies -AcquirePolicyToken or -ChangeReference.
     /// </summary>
     public class AcquirePolicyTokenHandler : DelegatingHandler, ICloneable
     {
-        private readonly AzurePSCmdlet _cmdlet;
+        private readonly bool _shouldAcquire;
+        private readonly string _changeReference;
+        private readonly bool _isWhatIf;
+        private readonly ConcurrentQueue<string> _debugMessages;
+        private readonly HttpClient _tokenHttpClient;
+
         private const string TokenApiVersion = "2025-03-01";
         private static readonly Regex SubscriptionIdRegex = new Regex(@"/subscriptions/([0-9a-fA-F-]{36})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly HashSet<string> _allowedWriteMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -44,32 +50,45 @@ namespace Microsoft.WindowsAzure.Commands.Common
         };
         private const string LogPrefix = "[AcquirePolicyTokenHandler]";
 
-        public AcquirePolicyTokenHandler(AzurePSCmdlet cmdlet)
+        /// <summary>
+        /// Creates a handler with explicit parameter values (no cmdlet reference needed).
+        /// </summary>
+        /// <param name="shouldAcquire">Whether the user requested policy token acquisition.</param>
+        /// <param name="changeReference">The change reference ID, or null if not specified.</param>
+        /// <param name="isWhatIf">Whether -WhatIf was specified (dry run).</param>
+        /// <param name="debugMessages">Queue for debug messages, or null.</param>
+        /// <param name="tokenHttpClient">Optional HttpClient for the token API call (for testing).</param>
+        public AcquirePolicyTokenHandler(
+            bool shouldAcquire,
+            string changeReference,
+            bool isWhatIf,
+            ConcurrentQueue<string> debugMessages,
+            HttpClient tokenHttpClient = null)
         {
-            _cmdlet = cmdlet;
+            _shouldAcquire = shouldAcquire;
+            _changeReference = changeReference;
+            _isWhatIf = isWhatIf;
+            _debugMessages = debugMessages;
+            _tokenHttpClient = tokenHttpClient;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             EnqueueDebug($"Intercept {request.Method} {request.RequestUri}");
 
-            bool allowedVerb = _allowedWriteMethods.Contains(request.Method.Method);
-            if (!allowedVerb)
+            if (!_allowedWriteMethods.Contains(request.Method.Method))
             {
                 EnqueueDebug("Skip: verb not allowed for token acquisition.");
                 return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
 
-            bool hasCmdlet = _cmdlet != null;
-            bool userRequested = hasCmdlet && _cmdlet.ShouldAcquirePolicyToken;
-            if (!userRequested)
+            if (!_shouldAcquire)
             {
                 EnqueueDebug("Skip: user did not request token (no -AcquirePolicyToken).");
                 return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
 
-            var isWhatIf = _cmdlet.MyInvocation?.BoundParameters?.ContainsKey("WhatIf") == true;
-            if (isWhatIf)
+            if (_isWhatIf)
             {
                 EnqueueDebug("Skip: -WhatIf present (dry run).");
                 return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
@@ -78,11 +97,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
             try
             {
                 var token = await AcquirePolicyTokenAsync(request, cancellationToken).ConfigureAwait(false);
-                
-                //Debug token, as is
-                // EnqueueDebug($"Token: {token}");
-                
-                
+
                 if (!string.IsNullOrEmpty(token))
                 {
                     if (request.Headers.Contains("x-ms-policy-external-evaluations"))
@@ -144,7 +159,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
                     httpMethod = originalRequest.Method.Method,
                     content = contentObj
                 },
-                changeReference = _cmdlet?.CurrentChangeReference
+                changeReference = _changeReference
             };
             EnqueueDebug("Payload prepared.");
 
@@ -165,7 +180,9 @@ namespace Microsoft.WindowsAzure.Commands.Common
                 tokenRequest.Headers.TryAddWithoutValidation("x-ms-authorization-auxiliary", auxValues);
             }
 
-            using (var http = new HttpClient())
+            var isOwnedClient = _tokenHttpClient == null;
+            var http = _tokenHttpClient ?? new HttpClient();
+            try
             {
                 EnqueueDebug($"POST acquirePolicyToken {tokenUri}");
                 var response = await http.SendAsync(tokenRequest, cancellationToken).ConfigureAwait(false);
@@ -188,7 +205,7 @@ namespace Microsoft.WindowsAzure.Commands.Common
                 }
                 else if (response.StatusCode == HttpStatusCode.Accepted)
                 {
-                    EnqueueDebug("202 Accepted received (async not supported)." );
+                    EnqueueDebug("202 Accepted received (async not supported).");
                     throw new InvalidOperationException("Asynchronous policy token acquisition (202 Accepted) is not supported.");
                 }
                 else
@@ -196,6 +213,10 @@ namespace Microsoft.WindowsAzure.Commands.Common
                     EnqueueDebug("Non-success status; will throw.");
                     throw new InvalidOperationException($"Policy token acquisition failed with {(int)response.StatusCode} {response.StatusCode}: {responseContent}");
                 }
+            }
+            finally
+            {
+                if (isOwnedClient) http.Dispose();
             }
         }
 
@@ -212,14 +233,14 @@ namespace Microsoft.WindowsAzure.Commands.Common
 
         public object Clone()
         {
-            return new AcquirePolicyTokenHandler(_cmdlet);
+            return new AcquirePolicyTokenHandler(_shouldAcquire, _changeReference, _isWhatIf, _debugMessages, _tokenHttpClient);
         }
 
         private void EnqueueDebug(string message)
         {
             try
             {
-                _cmdlet?.DebugMessages?.Enqueue($"{LogPrefix} {message}");
+                _debugMessages?.Enqueue($"{LogPrefix} {message}");
             }
             catch { }
         }

--- a/src/Common/AcquirePolicyTokenHandler.cs
+++ b/src/Common/AcquirePolicyTokenHandler.cs
@@ -53,12 +53,6 @@ namespace Microsoft.WindowsAzure.Commands.Common
         {
             EnqueueDebug($"Intercept {request.Method} {request.RequestUri}");
 
-            if (!(_cmdlet?.IsPolicyTokenFeatureEnabled() ?? false))
-            {
-                EnqueueDebug("Skip: feature disabled (EnableAcquirePolicyToken config set to false).");
-                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
-            }
-
             bool allowedVerb = _allowedWriteMethods.Contains(request.Method.Method);
             if (!allowedVerb)
             {
@@ -149,9 +143,8 @@ namespace Microsoft.WindowsAzure.Commands.Common
                     uri = originalRequest.RequestUri.ToString(),
                     httpMethod = originalRequest.Method.Method,
                     content = contentObj
-                }
-                // Phase 2: reintroduce when ChangeReference parameter is enabled
-                // ,changeReference = _cmdlet?.CurrentChangeReference
+                },
+                changeReference = _cmdlet?.CurrentChangeReference
             };
             EnqueueDebug("Payload prepared.");
 

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -181,7 +181,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             }
         }
 
-        internal string CurrentChangeReference
+        internal virtual string CurrentChangeReference
         {
             get
             {
@@ -195,7 +195,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             }
         }
 
-        internal bool ShouldAcquirePolicyToken
+        internal virtual bool ShouldAcquirePolicyToken
         {
             get
             {
@@ -368,8 +368,12 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                 // ignore if it failed.
             }
             
-            // Always add the acquire policy token handler; it will internally decide whether to act.
-            AzureSession.Instance.ClientFactory.AddHandler(new AcquirePolicyTokenHandler(this));
+            // Snapshot cmdlet state into the handler — no cmdlet reference held.
+            AzureSession.Instance.ClientFactory.AddHandler(new AcquirePolicyTokenHandler(
+                this.ShouldAcquirePolicyToken,
+                this.CurrentChangeReference,
+                this.MyInvocation?.BoundParameters?.ContainsKey("WhatIf") == true,
+                this.DebugMessages));
 
             AzureSession.Instance.ClientFactory.AddHandler(
                 new CmdletInfoHandler(this.CommandRuntime.ToString(),

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -26,6 +26,7 @@ using Microsoft.WindowsAzure.Commands.Common.Sanitizer;
 using Microsoft.WindowsAzure.Commands.Common.Utilities;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -41,7 +42,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
     /// <summary>
     /// Represents base class for all Azure cmdlets.
     /// </summary>
-    public abstract class AzurePSCmdlet : PSCmdlet, IDisposable
+    public abstract class AzurePSCmdlet : PSCmdlet, IDisposable, IDynamicParameters
     {
         private const string PSVERSION = "PSVersion";
         private const string DEFAULT_PSVERSION = "3.0.0.0";
@@ -177,6 +178,91 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                     return outputSanitizer;
 
                 return null;
+            }
+        }
+
+        // PHASE2: ChangeReference temporarily disabled, always null
+        // internal string CurrentChangeReference
+        // {
+        //     get
+        //     {
+        //         var bp = this.MyInvocation?.BoundParameters;
+        //         if (bp != null && bp.ContainsKey("ChangeReference"))
+        //         {
+        //             return bp["ChangeReference"] as string;
+        //         }
+
+        //         return null;
+        //     }
+        // }
+
+        /// <summary>
+        /// Determines whether the policy token feature is enabled.
+        /// Priority 1: environment variable AZ_ENABLE_POLICY_TOKEN overrides (1/0, true/false, yes/no).
+        /// Priority 2: Config key (EnablePolicyToken) set by Set-AzConfig.
+        /// Default: disabled (false).
+        /// </summary>
+        internal bool IsPolicyTokenFeatureEnabled()
+        {
+            try
+            {
+                var env = Environment.GetEnvironmentVariable("AZ_ENABLE_POLICY_TOKEN");
+                if (!string.IsNullOrEmpty(env))
+                {
+                    var trimmed = env.Trim();
+
+                    if (bool.TryParse(trimmed, out var b)) return b;
+                    if (string.Equals(trimmed, "1", StringComparison.Ordinal)) return true;
+                    if (string.Equals(trimmed, "0", StringComparison.Ordinal)) return false;
+                    
+                    switch (trimmed.ToLowerInvariant())
+                    {
+                        case "yes":
+                        case "on":
+                        case "enable":
+                        case "enabled":
+                            return true;
+                        case "no":
+                        case "off":
+                        case "disable":
+                        case "disabled":
+                            return false;
+                    }
+                }
+
+                // Config fallback (Set-AzConfig -EnablePolicyToken true)
+                if (AzureSession.Instance.TryGetComponent<IConfigManager>(nameof(IConfigManager), out var configManager))
+                {
+                    try
+                    {
+                        return configManager.GetConfigValue<bool>(ConfigKeysForCommon.EnablePolicyToken, MyInvocation);
+                    }
+                    catch { }
+                }
+            }
+            catch { }
+
+            // Default: disabled
+            return false;
+        }
+
+        internal bool ShouldAcquirePolicyToken
+        {
+            get
+            {
+                var bp = this.MyInvocation?.BoundParameters;
+                if (bp == null)
+                {
+                    return false;
+                }
+                if (!IsPolicyTokenFeatureEnabled())
+                {
+                    return false;
+                }
+                var acquire = bp.ContainsKey("AcquirePolicyToken") && ((SwitchParameter)bp["AcquirePolicyToken"]).IsPresent;
+                // PHASE2: ChangeReference disabled; ignore for now
+                // var changeRef = bp.ContainsKey("ChangeReference") && !string.IsNullOrEmpty(bp["ChangeReference"] as string);
+                return acquire; // || changeRef;
             }
         }
 
@@ -324,7 +410,9 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             AzureSession.Instance.ClientFactory.AddUserAgent("AzurePowershell", string.Format("v{0}", AzVersion));
             AzureSession.Instance.ClientFactory.AddUserAgent(PSVERSION, string.Format("v{0}", PowerShellVersion));
             AzureSession.Instance.ClientFactory.AddUserAgent(ModuleName, this.ModuleVersion);
-            try {
+            
+            try
+            {
                 string hostEnv = AzurePSCmdlet.getEnvUserAgent();
                 if (!String.IsNullOrWhiteSpace(hostEnv))
                 {
@@ -335,11 +423,14 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             {
                 // ignore if it failed.
             }
+            
+            // Always add the acquire policy token handler; it will internally decide whether to act.
+            AzureSession.Instance.ClientFactory.AddHandler(new AcquirePolicyTokenHandler(this));
 
             AzureSession.Instance.ClientFactory.AddHandler(
                 new CmdletInfoHandler(this.CommandRuntime.ToString(),
                     this.ParameterSetName, this._clientRequestId));
-
+            
         }
 
         protected virtual void TearDownHttpClientPipeline()
@@ -356,8 +447,80 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             {
                 // ignore if it failed.
             }
+
             AzureSession.Instance.ClientFactory.RemoveUserAgent(ModuleName);
+            AzureSession.Instance.ClientFactory.RemoveHandler(typeof(AcquirePolicyTokenHandler));
             AzureSession.Instance.ClientFactory.RemoveHandler(typeof(CmdletInfoHandler));
+        }
+
+        /// <summary>
+        /// Dynamic parameters for policy token acquisition and any previously registered dynamic parameters (e.g. AsJob).
+        /// </summary>
+        public virtual object GetDynamicParameters()
+        {
+            var dict = new RuntimeDefinedParameterDictionary();
+
+            // Preserve existing dynamic parameters if any were registered via RegisterDynamicParameters
+            if (AsJobDynamicParameters != null)
+            {
+                foreach (var kv in AsJobDynamicParameters)
+                {
+                    dict[kv.Key] = kv.Value;
+                }
+            }
+
+            // FEATURE FLAG: only surface parameters when feature enabled
+            if (!IsPolicyTokenFeatureEnabled())
+            {
+                return dict;
+            }
+
+            // Do not add parameters for read-only cmdlets (Get-*/List-*/Show-*)
+            var commandName = this.MyInvocation?.MyCommand?.Name ?? string.Empty;
+
+            if (commandName.StartsWith("Get", StringComparison.OrdinalIgnoreCase)
+                || commandName.EndsWith("List", StringComparison.OrdinalIgnoreCase)
+                || commandName.EndsWith("Show", StringComparison.OrdinalIgnoreCase))
+            {
+                return dict;
+            }
+
+            try
+            {
+                var acquireParam = new RuntimeDefinedParameter(
+                    "AcquirePolicyToken",
+                    typeof(SwitchParameter),
+                    new Collection<Attribute>
+                    {
+                        new ParameterAttribute
+                        {
+                            HelpMessage = "Acquire an Azure Policy token automatically for this resource operation.",
+                            ParameterSetName = ParameterAttribute.AllParameterSets
+                        }
+                    });
+                dict.Add("AcquirePolicyToken", acquireParam);
+
+                /* PHASE2 (behind same feature flag): ChangeReference dynamic parameter
+                var changeRefParam = new RuntimeDefinedParameter(
+                    "ChangeReference",
+                    typeof(string),
+                    new Collection<Attribute>
+                    {
+                        new ParameterAttribute
+                        {
+                            HelpMessage = "The related change reference ID for this resource operation.",
+                            ParameterSetName = ParameterAttribute.AllParameterSets
+                        }
+                    });
+                dict.Add("ChangeReference", changeRefParam);
+                */
+            }
+            catch
+            {
+                // Ignore dynamic parameter creation issues.
+            }
+
+            return dict;
         }
 
         /// <summary>

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -181,69 +181,18 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             }
         }
 
-        // PHASE2: ChangeReference temporarily disabled, always null
-        // internal string CurrentChangeReference
-        // {
-        //     get
-        //     {
-        //         var bp = this.MyInvocation?.BoundParameters;
-        //         if (bp != null && bp.ContainsKey("ChangeReference"))
-        //         {
-        //             return bp["ChangeReference"] as string;
-        //         }
-
-        //         return null;
-        //     }
-        // }
-
-        /// <summary>
-        /// Determines whether the policy token feature is enabled.
-        /// Priority 1: environment variable AZ_ENABLE_POLICY_TOKEN overrides (1/0, true/false, yes/no).
-        /// Priority 2: Config key (EnablePolicyToken) set by Set-AzConfig.
-        /// Default: disabled (false).
-        /// </summary>
-        internal bool IsPolicyTokenFeatureEnabled()
+        internal string CurrentChangeReference
         {
-            try
+            get
             {
-                var env = Environment.GetEnvironmentVariable("AZ_ENABLE_POLICY_TOKEN");
-                if (!string.IsNullOrEmpty(env))
+                var bp = this.MyInvocation?.BoundParameters;
+                if (bp != null && bp.ContainsKey("ChangeReference"))
                 {
-                    var trimmed = env.Trim();
-
-                    if (bool.TryParse(trimmed, out var b)) return b;
-                    if (string.Equals(trimmed, "1", StringComparison.Ordinal)) return true;
-                    if (string.Equals(trimmed, "0", StringComparison.Ordinal)) return false;
-                    
-                    switch (trimmed.ToLowerInvariant())
-                    {
-                        case "yes":
-                        case "on":
-                        case "enable":
-                        case "enabled":
-                            return true;
-                        case "no":
-                        case "off":
-                        case "disable":
-                        case "disabled":
-                            return false;
-                    }
+                    return bp["ChangeReference"] as string;
                 }
 
-                // Config fallback (Set-AzConfig -EnablePolicyToken true)
-                if (AzureSession.Instance.TryGetComponent<IConfigManager>(nameof(IConfigManager), out var configManager))
-                {
-                    try
-                    {
-                        return configManager.GetConfigValue<bool>(ConfigKeysForCommon.EnablePolicyToken, MyInvocation);
-                    }
-                    catch { }
-                }
+                return null;
             }
-            catch { }
-
-            // Default: disabled
-            return false;
         }
 
         internal bool ShouldAcquirePolicyToken
@@ -255,14 +204,9 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                 {
                     return false;
                 }
-                if (!IsPolicyTokenFeatureEnabled())
-                {
-                    return false;
-                }
                 var acquire = bp.ContainsKey("AcquirePolicyToken") && ((SwitchParameter)bp["AcquirePolicyToken"]).IsPresent;
-                // PHASE2: ChangeReference disabled; ignore for now
-                // var changeRef = bp.ContainsKey("ChangeReference") && !string.IsNullOrEmpty(bp["ChangeReference"] as string);
-                return acquire; // || changeRef;
+                var changeRef = bp.ContainsKey("ChangeReference") && !string.IsNullOrEmpty(bp["ChangeReference"] as string);
+                return acquire || changeRef;
             }
         }
 
@@ -469,12 +413,6 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                 }
             }
 
-            // FEATURE FLAG: only surface parameters when feature enabled
-            if (!IsPolicyTokenFeatureEnabled())
-            {
-                return dict;
-            }
-
             // Do not add parameters for read-only cmdlets (Get-*/List-*/Show-*)
             var commandName = this.MyInvocation?.MyCommand?.Name ?? string.Empty;
 
@@ -500,7 +438,6 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                     });
                 dict.Add("AcquirePolicyToken", acquireParam);
 
-                /* PHASE2 (behind same feature flag): ChangeReference dynamic parameter
                 var changeRefParam = new RuntimeDefinedParameter(
                     "ChangeReference",
                     typeof(string),
@@ -513,7 +450,6 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                         }
                     });
                 dict.Add("ChangeReference", changeRefParam);
-                */
             }
             catch
             {

--- a/src/Common/AzurePSCmdlet.cs
+++ b/src/Common/AzurePSCmdlet.cs
@@ -181,14 +181,17 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
             }
         }
 
+        internal const string AcquirePolicyTokenParamName = "AcquirePolicyToken";
+        internal const string ChangeReferenceParamName = "ChangeReference";
+
         internal virtual string CurrentChangeReference
         {
             get
             {
                 var bp = this.MyInvocation?.BoundParameters;
-                if (bp != null && bp.ContainsKey("ChangeReference"))
+                if (bp != null && bp.ContainsKey(ChangeReferenceParamName))
                 {
-                    return bp["ChangeReference"] as string;
+                    return bp[ChangeReferenceParamName] as string;
                 }
 
                 return null;
@@ -204,8 +207,8 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                 {
                     return false;
                 }
-                var acquire = bp.ContainsKey("AcquirePolicyToken") && ((SwitchParameter)bp["AcquirePolicyToken"]).IsPresent;
-                var changeRef = bp.ContainsKey("ChangeReference") && !string.IsNullOrEmpty(bp["ChangeReference"] as string);
+                var acquire = bp.ContainsKey(AcquirePolicyTokenParamName) && ((SwitchParameter)bp[AcquirePolicyTokenParamName]).IsPresent;
+                var changeRef = bp.ContainsKey(ChangeReferenceParamName) && !string.IsNullOrEmpty(bp[ChangeReferenceParamName] as string);
                 return acquire || changeRef;
             }
         }
@@ -417,20 +420,21 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                 }
             }
 
-            // Do not add parameters for read-only cmdlets (Get-*/List-*/Show-*)
+            // Do not add parameters for read-only cmdlets (Get-*/Test-*/List-*/Show-*)
             var commandName = this.MyInvocation?.MyCommand?.Name ?? string.Empty;
 
             if (commandName.StartsWith("Get", StringComparison.OrdinalIgnoreCase)
-                || commandName.EndsWith("List", StringComparison.OrdinalIgnoreCase)
-                || commandName.EndsWith("Show", StringComparison.OrdinalIgnoreCase))
+                || commandName.StartsWith("Test", StringComparison.OrdinalIgnoreCase)
+                || commandName.StartsWith("List", StringComparison.OrdinalIgnoreCase)
+                || commandName.StartsWith("Show", StringComparison.OrdinalIgnoreCase))
             {
                 return dict;
             }
 
-            try
+            if (!dict.ContainsKey(AcquirePolicyTokenParamName))
             {
-                var acquireParam = new RuntimeDefinedParameter(
-                    "AcquirePolicyToken",
+                dict.Add(AcquirePolicyTokenParamName, new RuntimeDefinedParameter(
+                    AcquirePolicyTokenParamName,
                     typeof(SwitchParameter),
                     new Collection<Attribute>
                     {
@@ -439,25 +443,22 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
                             HelpMessage = "Acquire an Azure Policy token automatically for this resource operation.",
                             ParameterSetName = ParameterAttribute.AllParameterSets
                         }
-                    });
-                dict.Add("AcquirePolicyToken", acquireParam);
+                    }));
+            }
 
-                var changeRefParam = new RuntimeDefinedParameter(
-                    "ChangeReference",
+            if (!dict.ContainsKey(ChangeReferenceParamName))
+            {
+                dict.Add(ChangeReferenceParamName, new RuntimeDefinedParameter(
+                    ChangeReferenceParamName,
                     typeof(string),
                     new Collection<Attribute>
                     {
                         new ParameterAttribute
                         {
-                            HelpMessage = "The related change reference ID for this resource operation.",
+                            HelpMessage = "The change reference resource ID for this resource operation.",
                             ParameterSetName = ParameterAttribute.AllParameterSets
                         }
-                    });
-                dict.Add("ChangeReference", changeRefParam);
-            }
-            catch
-            {
-                // Ignore dynamic parameter creation issues.
+                    }));
             }
 
             return dict;

--- a/src/Common/Utilities/GeneralUtilities.cs
+++ b/src/Common/Utilities/GeneralUtilities.cs
@@ -37,7 +37,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
     {
         private static Assembly assembly = Assembly.GetExecutingAssembly();
 
-    private static List<string> AuthorizationHeaderNames = new List<string>() { "Authorization", "x-ms-policy-external-evaluations" };
+        private static List<string> AuthorizationHeaderNames = new List<string>() { "Authorization", "x-ms-policy-external-evaluations" };
 
         // this is only used to determine cutoff for streams (not xml or json).
         private const int StreamCutOffSize = 10 * 1024; //10KB

--- a/src/Common/Utilities/GeneralUtilities.cs
+++ b/src/Common/Utilities/GeneralUtilities.cs
@@ -37,7 +37,7 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
     {
         private static Assembly assembly = Assembly.GetExecutingAssembly();
 
-        private static List<string> AuthorizationHeaderNames = new List<string>() { "Authorization" };
+    private static List<string> AuthorizationHeaderNames = new List<string>() { "Authorization", "x-ms-policy-external-evaluations" };
 
         // this is only used to determine cutoff for streams (not xml or json).
         private const int StreamCutOffSize = 10 * 1024; //10KB

--- a/src/ResourceManager.Test/AzureRMCmdletUnitTests.cs
+++ b/src/ResourceManager.Test/AzureRMCmdletUnitTests.cs
@@ -29,8 +29,11 @@ namespace Microsoft.Azure.Commands.ResourceManager.Test
             var positive = new PositiveCmdlet();
             var dynamicParameters = positive.GetDynamicParameters() as RuntimeDefinedParameterDictionary;
             Assert.NotNull(dynamicParameters);
-            Assert.Single(dynamicParameters);
+            // AcquirePolicyToken + ChangeReference + SubscriptionId = 3
+            Assert.Equal(3, dynamicParameters.Count);
             Assert.NotNull(dynamicParameters["SubscriptionId"]);
+            Assert.NotNull(dynamicParameters["AcquirePolicyToken"]);
+            Assert.NotNull(dynamicParameters["ChangeReference"]);
         }
 
         [Fact]
@@ -38,7 +41,10 @@ namespace Microsoft.Azure.Commands.ResourceManager.Test
         {
             var negative = new NegativeCmdlet();
             var dynamicParameters = negative.GetDynamicParameters() as RuntimeDefinedParameterDictionary;
-            Assert.Empty(dynamicParameters);
+            // AcquirePolicyToken + ChangeReference = 2 (no SubscriptionId since no [SupportsSubscriptionId])
+            Assert.Equal(2, dynamicParameters.Count);
+            Assert.NotNull(dynamicParameters["AcquirePolicyToken"]);
+            Assert.NotNull(dynamicParameters["ChangeReference"]);
         }
 
         [Fact]
@@ -49,10 +55,12 @@ namespace Microsoft.Azure.Commands.ResourceManager.Test
             var positiveWithOwnParam = new PositiveCmdletWithOwnDynamicParam();
             var dynamicParameters = positiveWithOwnParam.GetDynamicParameters() as RuntimeDefinedParameterDictionary;
             Assert.NotNull(dynamicParameters);
-            Assert.Collection(dynamicParameters,
-                pair => { Assert.Equal("SubscriptionId", pair.Key); },
-                pair => { Assert.Equal("DP", pair.Key); }
-            );
+            // AcquirePolicyToken + ChangeReference + SubscriptionId + DP = 4
+            Assert.Equal(4, dynamicParameters.Count);
+            Assert.NotNull(dynamicParameters["AcquirePolicyToken"]);
+            Assert.NotNull(dynamicParameters["ChangeReference"]);
+            Assert.NotNull(dynamicParameters["SubscriptionId"]);
+            Assert.NotNull(dynamicParameters["DP"]);
         }
 
         [SupportsSubscriptionId]

--- a/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
+++ b/src/ResourceManager/Version2016_09_01/AzureRMCmdlet.cs
@@ -651,9 +651,9 @@ namespace Microsoft.Azure.Commands.ResourceManager.Common
             DebugMessages.Enqueue(args.Message);
         }
 
-        public object GetDynamicParameters()
+        public override object GetDynamicParameters()
         {
-            var parameters = new RuntimeDefinedParameterDictionary();
+            var parameters = base.GetDynamicParameters() as RuntimeDefinedParameterDictionary ?? new RuntimeDefinedParameterDictionary();
 
             // add `-SubscriptionId` if the cmdlet has [SupportsSubscriptionId] attribute
             if (GetType().IsDefined(typeof(SupportsSubscriptionIdAttribute), true))


### PR DESCRIPTION
## Add Change Safety support: AcquirePolicyToken and ChangeReference parameters

### Summary

Adds Change Safety protocol support to Azure PowerShell, matching Azure CLI parity. Two new dynamic parameters (`-AcquirePolicyToken` and `-ChangeReference`) are automatically available on all write cmdlets but excluded from read-only cmdlets (Get/List/Show).

Main Repo PR: https://github.com/Azure/azure-powershell/pull/29222/

### What this does

When a user passes `-AcquirePolicyToken` or `-ChangeReference`, the handler:
1. Intercepts outgoing PUT/POST/DELETE/PATCH requests
2. Calls `POST /subscriptions/{id}/providers/Microsoft.Authorization/acquirePolicyToken` with operation details and change reference
3. Attaches the returned token as `x-ms-policy-external-evaluations` header on the original request

When neither parameter is passed, **there is zero impact** on existing behavior.

### Files changed

| File | Change |
|------|--------|
| `AzurePSCmdlet.cs` | Added `GetDynamicParameters()` virtual method, `ShouldAcquirePolicyToken`, `CurrentChangeReference` |
| `AcquirePolicyTokenHandler.cs` | New `DelegatingHandler` for token acquisition (api-version `2025-03-01`) |
| `AzureRMCmdlet.cs` | Changed `GetDynamicParameters()` to `override` to chain base parameters |
| `ConfigKeysForCommon.cs` | Removed `EnablePolicyToken` feature flag (always-on, matching Azure CLI) |
| `GeneralUtilities.cs` | Added `x-ms-policy-external-evaluations` to sanitized header list |
| `AzureRMCmdletUnitTests.cs` | Updated assertions for new dynamic parameters |
| `Common.Test/` | **New** — 61 unit tests for handler, payload format, regression safety |

### Testing

- 61 new unit tests in `Common.Test`
- 41 updated tests in `ResourceManager.Test`
- All 140+ tests pass across all test suites
- End-to-end validated with connected repos (Storage, IotHub modules)