### PR TITLE
populate MicrosoftGraphUrl when ARM metadata omits trailing slash

### DIFF
--- a/src/Authentication.Abstractions.Test/AzureEnvironmentTests.cs
+++ b/src/Authentication.Abstractions.Test/AzureEnvironmentTests.cs
@@ -144,5 +144,39 @@ namespace Authentication.Abstractions.Test
             Assert.Empty(armEnvironments[EnvironmentName.AzureChinaCloud].GalleryUrl);
             Assert.Empty(armEnvironments[EnvironmentName.AzureUSGovernment].GalleryUrl);
         }
+
+        [Fact]
+        public void TestArmMicrosoftGraphResourceIdWithoutTrailingSlash()
+        {
+            Environment.SetEnvironmentVariable(ArmMetadataEnvVariable, @"TestData/ArmResponseMicrosoftGraphNoTrailingSlash.json");
+            var armEnvironments = AzureEnvironment.InitializeBuiltInEnvironments(null, httpOperations: TestOperationsFactory.Create().GetHttpOperations());
+
+            Assert.True(armEnvironments.ContainsKey("AzureBleuCloud"));
+            var env = armEnvironments["AzureBleuCloud"];
+
+            Assert.Equal(
+                "https://graph.microsoft.bleu.example",
+                env.GetProperty(AzureEnvironment.ExtendedEndpoint.MicrosoftGraphEndpointResourceId));
+            Assert.Equal(
+                "https://graph.microsoft.bleu.example",
+                env.GetProperty(AzureEnvironment.ExtendedEndpoint.MicrosoftGraphUrl));
+        }
+
+        [Fact]
+        public void TestArmMicrosoftGraphResourceIdWithTrailingSlash()
+        {
+            Environment.SetEnvironmentVariable(ArmMetadataEnvVariable, @"TestData/ArmResponseMicrosoftGraphWithTrailingSlash.json");
+            var armEnvironments = AzureEnvironment.InitializeBuiltInEnvironments(null, httpOperations: TestOperationsFactory.Create().GetHttpOperations());
+
+            Assert.True(armEnvironments.ContainsKey("AzureBleuCloud"));
+            var env = armEnvironments["AzureBleuCloud"];
+
+            Assert.Equal(
+                "https://graph.microsoft.bleu.example/",
+                env.GetProperty(AzureEnvironment.ExtendedEndpoint.MicrosoftGraphEndpointResourceId));
+            Assert.Equal(
+                "https://graph.microsoft.bleu.example",
+                env.GetProperty(AzureEnvironment.ExtendedEndpoint.MicrosoftGraphUrl));
+        }
     }
 }

--- a/src/Authentication.Abstractions.Test/TestData/ArmResponseMicrosoftGraphNoTrailingSlash.json
+++ b/src/Authentication.Abstractions.Test/TestData/ArmResponseMicrosoftGraphNoTrailingSlash.json
@@ -1,0 +1,42 @@
+[
+  {
+    "portal": "https://portal.bleu.example",
+    "authentication": {
+      "loginEndpoint": "https://login.bleu.example",
+      "audiences": [
+        "https://management.core.bleu.example/",
+        "https://management.bleu.example/"
+      ],
+      "tenant": "common",
+      "identityProvider": "AAD"
+    },
+    "media": "https://rest.media.bleu.example",
+    "graphAudience": "https://graph.windows.net/",
+    "graph": "https://graph.windows.net/",
+    "name": "AzureBleuCloud",
+    "suffixes": {
+      "azureDataLakeStoreFileSystem": "azuredatalakestore.bleu.example",
+      "acrLoginServer": "azurecr.bleu.example",
+      "sqlServerHostname": "database.bleu.example",
+      "azureDataLakeAnalyticsCatalogAndJob": "azuredatalakeanalytics.bleu.example",
+      "keyVaultDns": "vault.bleu.example",
+      "storage": "core.bleu.example",
+      "azureFrontDoorEndpointSuffix": "azurefd.bleu.example",
+      "mhsmDns": "managedhsm.bleu.example",
+      "synapseAnalytics": "dev.azuresynapse.bleu.example",
+      "attestationEndpoint": "attest.bleu.example"
+    },
+    "batch": "https://batch.core.bleu.example/",
+    "resourceManager": "https://management.bleu.example/",
+    "vmImageAliasDoc": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
+    "activeDirectoryDataLake": "https://datalake.bleu.example/",
+    "sqlManagement": "https://management.core.bleu.example:8443/",
+    "microsoftGraphResourceId": "https://graph.microsoft.bleu.example",
+    "appInsightsResourceId": "https://api.applicationinsights.bleu.example",
+    "appInsightsTelemetryChannelResourceId": "https://dc.applicationinsights.bleu.example/v2/track",
+    "attestationResourceId": "https://attest.bleu.example",
+    "synapseAnalyticsResourceId": "https://dev.azuresynapse.bleu.example",
+    "logAnalyticsResourceId": "https://api.loganalytics.bleu.example",
+    "ossrDbmsResourceId": "https://ossrdbms-aad.database.bleu.example"
+  }
+]

--- a/src/Authentication.Abstractions.Test/TestData/ArmResponseMicrosoftGraphWithTrailingSlash.json
+++ b/src/Authentication.Abstractions.Test/TestData/ArmResponseMicrosoftGraphWithTrailingSlash.json
@@ -1,0 +1,42 @@
+[
+  {
+    "portal": "https://portal.bleu.example",
+    "authentication": {
+      "loginEndpoint": "https://login.bleu.example",
+      "audiences": [
+        "https://management.core.bleu.example/",
+        "https://management.bleu.example/"
+      ],
+      "tenant": "common",
+      "identityProvider": "AAD"
+    },
+    "media": "https://rest.media.bleu.example",
+    "graphAudience": "https://graph.windows.net/",
+    "graph": "https://graph.windows.net/",
+    "name": "AzureBleuCloud",
+    "suffixes": {
+      "azureDataLakeStoreFileSystem": "azuredatalakestore.bleu.example",
+      "acrLoginServer": "azurecr.bleu.example",
+      "sqlServerHostname": "database.bleu.example",
+      "azureDataLakeAnalyticsCatalogAndJob": "azuredatalakeanalytics.bleu.example",
+      "keyVaultDns": "vault.bleu.example",
+      "storage": "core.bleu.example",
+      "azureFrontDoorEndpointSuffix": "azurefd.bleu.example",
+      "mhsmDns": "managedhsm.bleu.example",
+      "synapseAnalytics": "dev.azuresynapse.bleu.example",
+      "attestationEndpoint": "attest.bleu.example"
+    },
+    "batch": "https://batch.core.bleu.example/",
+    "resourceManager": "https://management.bleu.example/",
+    "vmImageAliasDoc": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json",
+    "activeDirectoryDataLake": "https://datalake.bleu.example/",
+    "sqlManagement": "https://management.core.bleu.example:8443/",
+    "microsoftGraphResourceId": "https://graph.microsoft.bleu.example/",
+    "appInsightsResourceId": "https://api.applicationinsights.bleu.example",
+    "appInsightsTelemetryChannelResourceId": "https://dc.applicationinsights.bleu.example/v2/track",
+    "attestationResourceId": "https://attest.bleu.example",
+    "synapseAnalyticsResourceId": "https://dev.azuresynapse.bleu.example",
+    "logAnalyticsResourceId": "https://api.loganalytics.bleu.example",
+    "ossrDbmsResourceId": "https://ossrdbms-aad.database.bleu.example"
+  }
+]

--- a/src/Authentication.Abstractions/AzureEnvironment.cs
+++ b/src/Authentication.Abstractions/AzureEnvironment.cs
@@ -204,13 +204,10 @@ namespace Microsoft.Azure.Commands.Common.Authentication.Abstractions
             if (!string.IsNullOrEmpty(armMetadata.MicrosoftGraphResourceId))
             {
                 azureEnvironment.SetProperty(ExtendedEndpoint.MicrosoftGraphEndpointResourceId, armMetadata.MicrosoftGraphResourceId);
-                // ARM endpoint only gives us graph resource ID (with ending slash "/"),
-                // we assume the Url (endpoint to where we send requests) equals the resource ID without the slash
-                if (armMetadata.MicrosoftGraphResourceId.EndsWith("/"))
-                {
-                    azureEnvironment.SetProperty(ExtendedEndpoint.MicrosoftGraphUrl,
-                        armMetadata.MicrosoftGraphResourceId.TrimEnd('/'));
-                }
+                // ARM endpoint gives us the graph resource ID, which may or may not include a trailing slash.
+                // We assume the Url (endpoint to where we send requests) equals the resource ID without the slash.
+                azureEnvironment.SetProperty(ExtendedEndpoint.MicrosoftGraphUrl,
+                    armMetadata.MicrosoftGraphResourceId.TrimEnd('/'));
             }
 
             if (!string.IsNullOrEmpty(armMetadata.AttestationResourceId))


### PR DESCRIPTION
Call TrimEnd('/') unconditionally so MicrosoftGraphUrl is derived whenever MicrosoftGraphResourceId is present. Behavior is unchanged for endpoints that already include a trailing slash.

Added test fixtures and unit tests covering both shapes:
  - ArmResponseMicrosoftGraphNoTrailingSlash.json
  - ArmResponseMicrosoftGraphWithTrailingSlash.json

Fixes ICM 787125398
Related: Azure/CLIPS#179